### PR TITLE
Separate `State` and `StoppingCriterionState` initialization

### DIFF
--- a/docs/src/interface.md
+++ b/docs/src/interface.md
@@ -83,7 +83,7 @@ function AlgorithmsInterface.initialize_state(
     )
     x0 = rand()
     iteration = 0
-    return HeronState(x0, 0, stopping_criterion_state)
+    return HeronState(x0, iteration, stopping_criterion_state)
 end
 
 function AlgorithmsInterface.initialize_state!(

--- a/docs/src/interface.md
+++ b/docs/src/interface.md
@@ -67,7 +67,7 @@ end
 
 ### Initialization
 
-In order to start implementing the core parts of our algorithm, we start at the very beginning.
+In order to begin implementing the core parts of our algorithm, we start at the very beginning.
 There are two main entry points provided by the interface:
 
 - [`initialize_state`](@ref) constructs an entirely new state for the algorithm
@@ -76,21 +76,21 @@ There are two main entry points provided by the interface:
 An example implementation might look like:
 
 ```@example Heron
-function AlgorithmsInterface.initialize_state(problem::SqrtProblem, algorithm::HeronAlgorithm; kwargs...)
-    x0 = rand() # random initial guess
-    stopping_criterion_state = initialize_state(problem, algorithm, algorithm.stopping_criterion)
+function AlgorithmsInterface.initialize_state(
+        problem::SqrtProblem, algorithm::HeronAlgorithm,
+        stopping_criterion_state::StoppingCriterionState;
+        kwargs...
+    )
+    x0 = rand()
+    iteration = 0
     return HeronState(x0, 0, stopping_criterion_state)
 end
 
-function AlgorithmsInterface.initialize_state!(problem::SqrtProblem, algorithm::HeronAlgorithm, state::HeronState; kwargs...)
-    # reset the state for the algorithm
-    state.iterate = rand()
-    state.iteration = 0
-    
-    # reset the state for the stopping criterion
-    state = AlgorithmsInterface.initialize_state!(
-        problem, algorithm, algorithm.stopping_criterion, state.stopping_criterion_state
+function AlgorithmsInterface.initialize_state!(
+        problem::SqrtProblem, algorithm::HeronAlgorithm, state::HeronState;
+        kwargs...
     )
+    state.iteration = 0
     return state
 end
 ```
@@ -171,6 +171,15 @@ Private = true
 ```@autodocs
 Modules = [AlgorithmsInterface]
 Pages = ["interface/state.jl"]
+Order = [:type, :function]
+Private = true
+```
+
+### Stopping Criteria
+
+```@autodocs
+Modules = [AlgorithmsInterface]
+Pages = ["interface/stopping.jl"]
 Order = [:type, :function]
 Private = true
 ```

--- a/docs/src/logging.md
+++ b/docs/src/logging.md
@@ -52,16 +52,21 @@ mutable struct HeronState <: State
     stopping_criterion_state
 end
 
-function AlgorithmsInterface.initialize_state(problem::SqrtProblem, algorithm::HeronAlgorithm; kwargs...)
+function AlgorithmsInterface.initialize_state(
+        problem::SqrtProblem, algorithm::HeronAlgorithm,
+        stopping_criterion_state::StoppingCriterionState;
+        kwargs...
+    )
     x0 = rand()
-    stopping_criterion_state = initialize_state(problem, algorithm, algorithm.stopping_criterion)
+    iteration = 0
     return HeronState(x0, 0, stopping_criterion_state)
 end
 
-function AlgorithmsInterface.initialize_state!(problem::SqrtProblem, algorithm::HeronAlgorithm, state::HeronState; kwargs...)
-    state.iterate = rand()
+function AlgorithmsInterface.initialize_state!(
+        problem::SqrtProblem, algorithm::HeronAlgorithm, state::HeronState;
+        kwargs...
+    )
     state.iteration = 0
-    initialize_state!(problem, algorithm, algorithm.stopping_criterion, state.stopping_criterion_state)
     return state
 end
 

--- a/src/AlgorithmsInterface.jl
+++ b/src/AlgorithmsInterface.jl
@@ -15,6 +15,7 @@ using ScopedValues
 include("interface/algorithm.jl")
 include("interface/problem.jl")
 include("interface/state.jl")
+include("interface/stopping.jl")
 include("interface/interface.jl")
 
 include("stopping_criterion.jl")

--- a/src/interface/interface.jl
+++ b/src/interface/interface.jl
@@ -1,13 +1,34 @@
 _doc_init_state = """
-    state = initialize_state(problem::Problem, algorithm::Algorithm; kwargs...)
-    state = initialize_state!(problem::Problem, algorithm::Algorithm, state::State; kwargs...)
+    state = initialize_state(
+        problem::Problem, algorithm::Algorithm,
+        [stopping_criterion_state::StoppingCriterionState];
+        kwargs...
+    )
+    state = initialize_state!(
+        problem::Problem, algorithm::Algorithm, state::State;
+        kwargs...
+    )
 
 Initialize a [`State`](@ref) based on a [`Problem`](@ref) and an [`Algorithm`](@ref).
 The `kwargs...` should allow to initialize for example the initial point.
 This can be done in-place for `state`, then only values that did change have to be provided.
+
+Note that since the returned state should also hold `state.stopping_criterion_state`,
+which will be used to keep the internal state of the stopping criterion, the out-of-place
+version receives this as one of its arguments. By default, that will be initialized separately
+through a call to [`initialize_stopping_state`](@ref) and provided as an argument.
+
+On the other hand, the in-place version is not responsible for initializing the `stopping_criterion_state`,
+as that will be handled separately by [`initialize_stopping_state!`](@ref).
+
+Users that which to handle the stopping criterion initialization in `initialize_state` manually
+should overload the 2-argument version, while by default the 3-argument version should be implemented.
 """
 
-function initialize_state end
+function initialize_state(problem::Problem, algorithm::Algorithm; kwargs...)
+    stopping_criterion_state = initialize_stopping_state(problem, algorithm; kwargs...)
+    return initialize_state(problem, algorithm, stopping_criterion_state; kwargs...)
+end
 
 @doc "$(_doc_init_state)"
 initialize_state(::Problem, ::Algorithm; kwargs...)
@@ -23,9 +44,10 @@ initialize_state!(::Problem, ::Algorithm, ::State; kwargs...)
     solve(problem::Problem, algorithm::Algorithm; kwargs...)
 
 Solve the [`Problem`](@ref) using an [`Algorithm`](@ref).
-The keyword arguments `kwargs...` have to provide enough details such that
-the corresponding state initialisation [`initialize_state`](@ref)`(problem, algorithm)`
-returns a state.
+
+The keyword arguments `kwargs...` have to provide enough details such that the corresponding
+state and stopping state initialisation [`initialize_state`](@ref)` and [`initialize_stopping_state`](@ref)
+can be used to return valid states and stopping states.
 
 By default this method continues to call [`solve!`](@ref).
 """
@@ -40,16 +62,18 @@ end
 Solve the [`Problem`](@ref) using an [`Algorithm`](@ref), starting from a given [`State`](@ref).
 The state is modified in-place.
 
-All keyword arguments are passed to the [`initialize_state!`](@ref)`(problem, algorithm, state)` function.
+All keyword arguments are passed to the [`initialize_state!`](@ref) and
+[`initialize_stopping_state!`](@ref) functions.
 """
 function solve!(problem::Problem, algorithm::Algorithm, state::State; kwargs...)
     # obtain logger once to minimize overhead from accessing ScopedValue
     # additionally handle logging initialization to enable stateful LoggingAction
     logger = algorithm_logger()
-    # initialize_logger(logger, problem, algorithm, state)
 
     # initialize the state and emit message
+    initialize_stopping_state!(problem, algorithm, state; kwargs...)
     initialize_state!(problem, algorithm, state; kwargs...)
+
     emit_message(logger, problem, algorithm, state, :Start)
 
     # main body of the algorithm
@@ -72,6 +96,7 @@ function solve!(problem::Problem, algorithm::Algorithm, state::State; kwargs...)
 end
 
 function step! end
+
 @doc """
     step!(problem::Problem, algorithm::Algorithm, state::State)
 

--- a/src/interface/stopping.jl
+++ b/src/interface/stopping.jl
@@ -1,0 +1,168 @@
+@doc """
+    StoppingCriterion
+
+An abstract type to represent a stopping criterion of an [`Algorithm`](@ref).
+
+A concrete [`StoppingCriterion`](@ref) should also implement a
+[`initialize_state(problem::Problem, algorithm::Algorithm, stopping_criterion::StoppingCriterion; kwargs...)`](@ref) function to create its accompanying
+[`StoppingCriterionState`](@ref).
+as well as the corresponding mutating variant to reset such a [`StoppingCriterionState`](@ref).
+
+It should usually implement
+
+* [`indicates_convergence`](@ref)`(stopping_criterion)`
+* [`indicates_convergence`](@ref)`(stopping_criterion, stopping_criterion_state)`
+* [`is_finished!`](@ref)`(problem, algorithm, state, stopping_criterion, stopping_criterion_state)`
+* [`is_finished`](@ref)`(problem, algorithm, state, stopping_criterion, stopping_criterion_state)`
+"""
+abstract type StoppingCriterion end
+
+@doc """
+    StoppingCriterionState
+
+An abstract type to represent a stopping criterion state within a [`State`](@ref).
+It represents the concrete state a [`StoppingCriterion`](@ref) is in.
+
+It should usually implement
+
+* [`get_reason`](@ref)`(stopping_criterion, stopping_criterion_state)`
+* [`indicates_convergence`](@ref)`(stopping_criterion, stopping_criterion_state)`
+* [`is_finished!`](@ref)`(problem, algorithm, state, stopping_criterion, stopping_criterion_state)`
+* [`is_finished`](@ref)`(problem, algorithm, state, stopping_criterion, stopping_criterion_state)`
+"""
+abstract type StoppingCriterionState end
+
+# Initialization
+# --------------
+_doc_init_stopping_state = """
+    stopping_criterion_state = initialize_stopping_state(
+        problem::Problem, algorithm::Algorithm
+        stopping_criterion::StoppingCriterion = algorithm.stopping_criterion;
+        kwargs...
+    )
+    stopping_criterion_state = initialize_stopping_state!(
+        problem::Problem, algorithm::Algorithm, state::State,
+        stopping_criterion::StoppingCriterion = algorithm.stopping_criterion,
+        stopping_criterion_state::StoppingCriterionState = state.stopping_criterion_state;
+        kwargs...
+    )
+
+Initialize a [`StoppingCriterionState`](@ref) based on a [`Problem`](@ref), [`Algorithm`](@ref),
+[`State`](@ref) triplet for a given [`StoppingCriterion`](@ref).
+By default, the `stopping_criterion` is retrieved from the `Algorithm` via `algorithm.stopping_criterion`.
+
+The first signature is used for setting up a completely new stopping criterion state, while the second
+simply resets a given state in-place.
+"""
+
+initialize_stopping_state(problem::Problem, algorithm::Algorithm; kwargs...) =
+    initialize_stopping_state(problem, algorithm, algorithm.stopping_criterion; kwargs...)
+
+@doc "$(_doc_init_stopping_state)"
+initialize_stopping_state(::Problem, ::Algorithm, ::StoppingCriterion; kwargs...)
+
+function initialize_stopping_state!(problem::Problem, algorithm::Algorithm, state::State; kwargs...)
+    return initialize_stopping_state!(
+        problem, algorithm, state, algorithm.stopping_criterion, state.stopping_criterion_state; kwargs...
+    )
+end
+
+@doc "$(_doc_init_stopping_state)"
+initialize_stopping_state!(::Problem, ::Algorithm, ::State, ::StoppingCriterion, ::StoppingCriterionState; kwargs...)
+
+
+# Convergence characterization
+# ----------------------------
+function get_reason end
+
+@doc """
+    get_reason(stopping_criterion::StoppingCriterion, stopping_criterion_state::StoppingCriterionState)
+
+Provide a reason in human readable text as to why a [`StoppingCriterion`](@ref) with [`StoppingCriterionState`](@ref) indicated to stop.
+If it does not indicate to stop, this should return `nothing`.
+
+Providing the iteration at which this indicated to stop in the reason would be preferable.
+"""
+get_reason(::StoppingCriterion, ::StoppingCriterionState)
+
+function indicates_convergence end
+@doc """
+    indicates_convergence(stopping_criterion::StoppingCriterion)
+
+Return whether or not a [`StoppingCriterion`](@ref) indicates convergence.
+"""
+indicates_convergence(stopping_criterion::StoppingCriterion)
+
+@doc """
+    indicates_convergence(stopping_criterion::StoppingCriterion, ::StoppingCriterionState)
+
+Return whether or not a [`StoppingCriterion`](@ref) indicates convergence when it is in [`StoppingCriterionState`](@ref).
+
+By default this checks whether the [`StoppingCriterion`](@ref) has actually stopped.
+If so it returns whether `stopping_criterion` itself indicates convergence, otherwise it returns `false`,
+since the algorithm has then not yet stopped.
+"""
+function indicates_convergence(
+        stopping_criterion::StoppingCriterion,
+        stopping_criterion_state::StoppingCriterionState,
+    )
+    return isnothing(get_reason(stopping_criterion, stopping_criterion_state)) &&
+        indicates_convergence(stopping_criterion)
+end
+
+# Convergence indication
+# ----------------------
+_doc_is_finished = """
+    is_finished(problem::Problem, algorithm::Algorithm, state::State)
+    is_finished(problem::Problem, algorithm::Algorithm, state::State, stopping_criterion::StoppingCriterion, stopping_criterion_state::StoppingCriterionState)
+    is_finished!(problem::Problem, algorithm::Algorithm, state::State)
+    is_finished!(problem::Problem, algorithm::Algorithm, state::State, stopping_criterion::StoppingCriterion, stopping_criterion_state::StoppingCriterionState)
+
+Indicate whether an [`Algorithm`](@ref) solving [`Problem`](@ref) is finished having reached
+a certain [`State`](@ref). The variant with three arguments by default extracts the
+[`StoppingCriterion`](@ref) and its [`StoppingCriterionState`](@ref) and their actual
+checks are performed in the implementation with five arguments.
+
+The mutating variant does alter the `stopping_criterion_state` and and should only be called
+once per iteration, the other one merely inspects the current status without mutation.
+"""
+
+@doc "$(_doc_is_finished)"
+function is_finished(problem::Problem, algorithm::Algorithm, state::State)
+    return is_finished(
+        problem, algorithm, state,
+        algorithm.stopping_criterion,
+        state.stopping_criterion_state,
+    )
+end
+
+@doc "$(_doc_is_finished)"
+is_finished(::Problem, ::Algorithm, ::State, ::StoppingCriterion, ::StoppingCriterionState)
+
+@doc "$(_doc_is_finished)"
+function is_finished!(problem::Problem, algorithm::Algorithm, state::State)
+    return is_finished!(
+        problem, algorithm, state,
+        algorithm.stopping_criterion,
+        state.stopping_criterion_state,
+    )
+end
+
+@doc "$(_doc_is_finished)"
+is_finished!(::Problem, ::Algorithm, ::State, ::StoppingCriterion, ::StoppingCriterionState)
+
+@doc """
+    summary(io::IO, stopping_criterion::StoppingCriterion, stopping_criterion_state::StoppingCriterionState)
+
+Provide a summary of the status of a stopping criterion – its parameters and whether
+it currently indicates to stop. It should not be longer than one line
+
+# Example
+
+For the [`StopAfterIteration`](@ref) criterion, the summary looks like
+
+```
+Max Iterations (15): not reached
+```
+"""
+Base.summary(io::IO, ::StoppingCriterion, ::StoppingCriterionState)

--- a/test/logging.jl
+++ b/test/logging.jl
@@ -13,27 +13,26 @@ mutable struct LogDummyState{S <: StoppingCriterionState} <: State
 end
 
 # State initialization for the dummy algorithm
-function AlgorithmsInterface.initialize_state(problem::LogDummyProblem, algorithm::LogDummyAlgorithm; kwargs...)
-    sc_state = initialize_state(problem, algorithm, algorithm.stopping_criterion; kwargs...)
-    return LogDummyState(0.0, 0, sc_state)
-end
-function AlgorithmsInterface.initialize_state!(
-        problem::LogDummyProblem,
-        algorithm::LogDummyAlgorithm,
-        state::LogDummyState;
+function AlgorithmsInterface.initialize_state(
+        problem::LogDummyProblem, algorithm::LogDummyAlgorithm,
+        stopping_criterion_state::StoppingCriterionState;
         kwargs...
     )
-    initialize_state!(problem, algorithm, algorithm.stopping_criterion, state.stopping_criterion_state; kwargs...)
-    state.iterate = 0.0
+    iteration = 0
+    iterate = 0.0 # hardcode initial guess to 0.0
+    return LogDummyState(iterate, iteration, stopping_criterion_state)
+end
+function AlgorithmsInterface.initialize_state!(
+        problem::LogDummyProblem, algorithm::LogDummyAlgorithm, state::LogDummyState;
+        kwargs...
+    )
     state.iteration = 0
     return state
 end
 
 # One trivial step per iteration (not relevant for the logging test)
 function AlgorithmsInterface.step!(
-        ::LogDummyProblem,
-        ::LogDummyAlgorithm,
-        state::LogDummyState,
+        ::LogDummyProblem, ::LogDummyAlgorithm, state::LogDummyState,
     )
     state.iterate += 1.0
     return state

--- a/test/newton.jl
+++ b/test/newton.jl
@@ -25,23 +25,21 @@ end
 
 # Implementing the algorithm
 # --------------------------
-function initialize_state(problem::RootFindingProblem, algorithm::NewtonMethod)
-    scs = initialize_state(problem, algorithm, algorithm.stopping_criterion)
-    return NewtonState(0, 1.0, scs) # hardcode initial guess to 1.0
+function initialize_state(
+        problem::RootFindingProblem, algorithm::NewtonMethod,
+        stopping_criterion_state::StoppingCriterionState;
+        kwargs...
+    )
+    iteration = 0
+    iterate = 1.0 # hardcode initial guess to 1.0
+    return NewtonState(iteration, iterate, stopping_criterion_state)
 end
+
 function initialize_state!(
-        problem::RootFindingProblem,
-        algorithm::NewtonMethod,
-        state::NewtonState,
+        problem::RootFindingProblem, algorithm::NewtonMethod, state::NewtonState;
+        kwargs...
     )
     state.iteration = 0
-    state.iterate = 1.0
-    initialize_state!(
-        problem,
-        algorithm,
-        algorithm.stopping_criterion,
-        state.stopping_criterion_state,
-    )
     return state
 end
 


### PR DESCRIPTION
This is a slight refactor of the initialization procedure, where I did the following

- Separate out the initialization of the state and stopping state, such you don't need to remember to call `initialize_state!` on the stopping state.
- Update the docs to include a custom stopping implementation with and without stateful stopping criterion
- Update the docs and tests to no longer reset the `iterate` in the `initialize_state!` calls, and only generate a random starting point in `initialize_state` as this led to confusion in #8. The idea is that `initialize_state!` really means making sure everything is set up to correctly start running the algorithm, which does not necessarily include a reset of the `iterate` but rather means setup like caches, counters, auxiliary memory etc.
