### PR TITLE
Interface improvements: `finalize_state!` and deduplicate `initialize_state(!)` calls

### DIFF
--- a/docs/src/interface.md
+++ b/docs/src/interface.md
@@ -128,13 +128,14 @@ With these definitions in place you can already run (assuming you also choose a 
 function heron_sqrt(x; maxiter = 10)
     prob = SqrtProblem(x)
     alg  = HeronAlgorithm(StopAfterIteration(maxiter))
-    state = solve(prob, alg)  # allocates & runs
-    return state.iterate
+    return solve(prob, alg)  # allocates & runs
 end
 
 println("Approximate sqrt: ", heron_sqrt(16.0))
 ```
 
+Note that [`solve`](@ref) will default to returning `state.iterate`.
+If desired, this can be customized by altering [`finalize_state!`](@ref).
 We will refine this example with better halting logic and logging shortly.
 
 ## Reference: Core interface types & functions

--- a/docs/src/logging.md
+++ b/docs/src/logging.md
@@ -75,8 +75,7 @@ end
 function heron_sqrt(x; stopping_criterion = StopAfterIteration(10))
     prob = SqrtProblem(x)
     alg  = HeronAlgorithm(stopping_criterion)
-    state = solve(prob, alg)  # allocates & runs
-    return state.iterate
+    return solve(prob, alg)  # allocates & runs
 end
 nothing # hide
 ```
@@ -329,7 +328,7 @@ function solve!(problem::Problem, algorithm::Algorithm, state::State; kwargs...)
     
     emit_message(problem, algorithm, state, :Stop)
     
-    return state
+    return finalize_state!(problem, algorithm, state)
 end
 ```
 

--- a/docs/src/stopping_criterion.md
+++ b/docs/src/stopping_criterion.md
@@ -112,8 +112,7 @@ We can again combine everything into a single function, but now make the stoppin
 function heron_sqrt(x; stopping_criterion)
     prob = SqrtProblem(x)
     alg  = HeronAlgorithm(stopping_criterion)
-    state = solve(prob, alg)  # allocates & runs
-    return state.iterate, state.iteration
+    return solve(prob, alg)  # allocates & runs
 end
 
 heron_sqrt(2; stopping_criterion = StopAfterIteration(10))

--- a/src/AlgorithmsInterface.jl
+++ b/src/AlgorithmsInterface.jl
@@ -25,7 +25,7 @@ export Algorithm, Problem, State
 export initialize_state, initialize_state!
 export finalize_state!
 
-export step!, solve, solve!
+export step!, solve, solve!, solve_loop!
 
 # stopping criteria
 export StoppingCriterion, StoppingCriterionState

--- a/src/AlgorithmsInterface.jl
+++ b/src/AlgorithmsInterface.jl
@@ -23,6 +23,7 @@ include("logging.jl")
 # general interface
 export Algorithm, Problem, State
 export initialize_state, initialize_state!
+export finalize_state!
 
 export step!, solve, solve!
 

--- a/src/interface/interface.jl
+++ b/src/interface/interface.jl
@@ -40,8 +40,33 @@ returns a state.
 By default this method continues to call [`solve!`](@ref).
 """
 function solve(problem::Problem, algorithm::Algorithm; kwargs...)
+    # obtain logger once to minimize overhead from accessing ScopedValue
+    # additionally handle logging initialization to enable stateful LoggingAction
+    logger = algorithm_logger()
+    # initialize_logger(logger, problem, algorithm, state)
+
+    # initialize the state and emit message
     state = initialize_state(problem, algorithm; kwargs...)
-    return solve!(problem, algorithm, state; kwargs...)
+    emit_message(logger, problem, algorithm, state, :Start)
+
+    # main body of the algorithm
+    while !is_finished!(problem, algorithm, state)
+        # logging event between convergence check and algorithm step
+        emit_message(logger, problem, algorithm, state, :PreStep)
+
+        # algorithm step
+        increment!(state)
+        step!(problem, algorithm, state)
+
+        # logging event between algorithm step and convergence check
+        emit_message(logger, problem, algorithm, state, :PostStep)
+    end
+
+    # emit message about finished state
+    output = finalize_state!(problem, algorithm, state)
+    emit_message(logger, problem, algorithm, state, :Stop)
+
+    return output
 end
 
 @doc """

--- a/src/interface/interface.jl
+++ b/src/interface/interface.jl
@@ -43,13 +43,19 @@ function solve(problem::Problem, algorithm::Algorithm; kwargs...)
     # obtain logger once to minimize overhead from accessing ScopedValue
     # additionally handle logging initialization to enable stateful LoggingAction
     logger = algorithm_logger()
-    # initialize_logger(logger, problem, algorithm, state)
 
     # initialize the state and emit message
     state = initialize_state(problem, algorithm; kwargs...)
     emit_message(logger, problem, algorithm, state, :Start)
 
-    return _solve_body!(problem, algorithm, state, logger)
+    # main loop
+    state = solve_loop!(problem, algorithm, state)
+
+    # emit message about finished state
+    output = finalize_state!(problem, algorithm, state)
+    emit_message(logger, problem, algorithm, state, :Stop)
+
+    return output
 end
 
 @doc """
@@ -64,34 +70,41 @@ function solve!(problem::Problem, algorithm::Algorithm, state::State; kwargs...)
     # obtain logger once to minimize overhead from accessing ScopedValue
     # additionally handle logging initialization to enable stateful LoggingAction
     logger = algorithm_logger()
-    # initialize_logger(logger, problem, algorithm, state)
 
     # initialize the state and emit message
     initialize_state!(problem, algorithm, state; kwargs...)
     emit_message(logger, problem, algorithm, state, :Start)
 
-    return _solve_body!(problem, algorithm, state, logger)
-end
-
-function _solve_body!(problem::Problem, algorithm::Algorithm, state::State, logger)
-    # main body of the algorithm
-    while !is_finished!(problem, algorithm, state)
-        # logging event between convergence check and algorithm step
-        emit_message(logger, problem, algorithm, state, :PreStep)
-
-        # algorithm step
-        increment!(state)
-        step!(problem, algorithm, state)
-
-        # logging event between algorithm step and convergence check
-        emit_message(logger, problem, algorithm, state, :PostStep)
-    end
+    # main loop
+    state = solve_loop!(problem, algorithm, state)
 
     # emit message about finished state
     output = finalize_state!(problem, algorithm, state)
     emit_message(logger, problem, algorithm, state, :Stop)
 
     return output
+end
+
+"""
+    solve_loop!(problem::Problem, algorithm::Algorithm, state::State)
+
+Provide the main loop of the iterative `algorithm` for a given `problem` and starting `state`.
+
+This loop consists of:
+1. Checking for convergence with [`is_finished!`](@ref)
+2. Incrementing the state [`increment!`](@ref)
+3. Performing a step [`step!`](@ref)
+4. Repeat
+"""
+function solve_loop!(problem::Problem, algorithm::Algorithm, state::State)
+    logger = algorithm_logger()
+    while !is_finished!(problem, algorithm, state)
+        emit_message(logger, problem, algorithm, state, :PreStep)
+        increment!(state)
+        step!(problem, algorithm, state)
+        emit_message(logger, problem, algorithm, state, :PostStep)
+    end
+    return state
 end
 
 function step! end

--- a/src/interface/interface.jl
+++ b/src/interface/interface.jl
@@ -22,10 +22,10 @@ initialize_state!(::Problem, ::Algorithm, ::State; kwargs...)
     output = finalize_state!(problem::Problem, algorithm::Algorithm, state::State)
 
 Finalize the solver and decide what values get returned from the [`solve!`](@ref) call.
-By default, this is a no-op and returns the `state`, but this allows for customization
-in cases where the details of the `state` can remain hidden.
+By default, this is a no-op and returns the `state.iterate`, but this allows for further
+customization in other cases, for example to clean up used resources or output other data.
 """
-finalize_state!(problem::Problem, algorithm::Algorithm, state::State) = state
+finalize_state!(problem::Problem, algorithm::Algorithm, state::State) = state.iterate
 
 # has to be defined before used in solve but is documented alphabetically after
 

--- a/src/interface/interface.jl
+++ b/src/interface/interface.jl
@@ -17,6 +17,16 @@ function initialize_state! end
 @doc "$(_doc_init_state)"
 initialize_state!(::Problem, ::Algorithm, ::State; kwargs...)
 
+
+"""
+    output = finalize_state!(problem::Problem, algorithm::Algorithm, state::State)
+
+Finalize the solver and decide what values get returned from the [`solve!`](@ref) call.
+By default, this is a no-op and returns the `state`, but this allows for customization
+in cases where the details of the `state` can remain hidden.
+"""
+finalize_state!(problem::Problem, algorithm::Algorithm, state::State) = state
+
 # has to be defined before used in solve but is documented alphabetically after
 
 @doc """
@@ -66,9 +76,10 @@ function solve!(problem::Problem, algorithm::Algorithm, state::State; kwargs...)
     end
 
     # emit message about finished state
+    output = finalize_state!(problem, algorithm, state)
     emit_message(logger, problem, algorithm, state, :Stop)
 
-    return state
+    return output
 end
 
 function step! end

--- a/src/interface/interface.jl
+++ b/src/interface/interface.jl
@@ -49,24 +49,7 @@ function solve(problem::Problem, algorithm::Algorithm; kwargs...)
     state = initialize_state(problem, algorithm; kwargs...)
     emit_message(logger, problem, algorithm, state, :Start)
 
-    # main body of the algorithm
-    while !is_finished!(problem, algorithm, state)
-        # logging event between convergence check and algorithm step
-        emit_message(logger, problem, algorithm, state, :PreStep)
-
-        # algorithm step
-        increment!(state)
-        step!(problem, algorithm, state)
-
-        # logging event between algorithm step and convergence check
-        emit_message(logger, problem, algorithm, state, :PostStep)
-    end
-
-    # emit message about finished state
-    output = finalize_state!(problem, algorithm, state)
-    emit_message(logger, problem, algorithm, state, :Stop)
-
-    return output
+    return _solve_body!(problem, algorithm, state, logger)
 end
 
 @doc """
@@ -87,6 +70,10 @@ function solve!(problem::Problem, algorithm::Algorithm, state::State; kwargs...)
     initialize_state!(problem, algorithm, state; kwargs...)
     emit_message(logger, problem, algorithm, state, :Start)
 
+    return _solve_body!(problem, algorithm, state, logger)
+end
+
+function _solve_body!(problem::Problem, algorithm::Algorithm, state::State, logger)
     # main body of the algorithm
     while !is_finished!(problem, algorithm, state)
         # logging event between convergence check and algorithm step

--- a/src/interface/interface.jl
+++ b/src/interface/interface.jl
@@ -52,10 +52,9 @@ function solve(problem::Problem, algorithm::Algorithm; kwargs...)
     state = solve_loop!(problem, algorithm, state)
 
     # emit message about finished state
-    output = finalize_state!(problem, algorithm, state)
     emit_message(logger, problem, algorithm, state, :Stop)
 
-    return output
+    return finalize_state!(problem, algorithm, state)
 end
 
 @doc """
@@ -79,10 +78,9 @@ function solve!(problem::Problem, algorithm::Algorithm, state::State; kwargs...)
     state = solve_loop!(problem, algorithm, state)
 
     # emit message about finished state
-    output = finalize_state!(problem, algorithm, state)
     emit_message(logger, problem, algorithm, state, :Stop)
 
-    return output
+    return finalize_state!(problem, algorithm, state)
 end
 
 """

--- a/test/newton.jl
+++ b/test/newton.jl
@@ -60,9 +60,9 @@ end
     problem = RootFindingProblem(x -> f(x, a), x -> df(x, a))
     algorithm1 = NewtonMethod(StopAfterIteration(8))
     solution1 = solve(problem, algorithm1)
-    @test solution1.iterate ≈ sqrt(a)
+    @test solution1 ≈ sqrt(a)
     algorithm2 = NewtonMethod(StopAfterIteration(10))
     solution2 = solve(problem, algorithm2)
-    @test solution2.iterate ≈ sqrt(a)
-    @test abs(solution2.iterate - sqrt(a)) < abs(solution1.iterate - sqrt(a))
+    @test solution2 ≈ sqrt(a)
+    @test abs(solution2 - sqrt(a)) < abs(solution1 - sqrt(a))
 end


### PR DESCRIPTION
This is a (long overdue) follow-up on some of the things that had been discussed but rejected in #9. The approach here is different, and I'm happy to hear some feedback.

### Changes

- The first thing I changed here is that I added a `finalize_state!` function, which is called at the end of the `solve(!)` routines. The main point is to just have a hook that provides the option of returning something different than the `state` from those calls. For example, it might be reasonable that `solve(problem, algorithm) -> solution`, instead of returning a `state` that still has all of the internal details. Additionally this function allows for doing some clean-up, for example it might be used for releasing some resources or caches that were acquired, or maybe to write the result to disk, ...

- The second thing relates more to the previous closed PR, where I think one of the main comments was that `solve` ends up first calling `initialize_state`, and then calls `solve!`, which ends up calling `initialize_state!`. Since `initialize_state` and `initialize_state!` should probably do the same thing, this effectively means that `solve` does that work twice, which isn't necessary. Here, I bypassed that in the most simple way I could come up with: just duplicate the body of `solve!`. We might wish to discuss a bit more about this though, since this effectively means that if anyone decides to overload `solve!`, they must also overload `solve` for these to remain consistent. I think we should probably aim for it never really being necessary to overload `solve(!)` in the first place, so this might be fine, but I could be missing something.