### PR TITLE
ParallelTestRunner.jl

### DIFF
--- a/src/stopping_criterion.jl
+++ b/src/stopping_criterion.jl
@@ -156,7 +156,7 @@ function Base.show(io::IO, ::MIME"text/plain", stop_when_all::StopWhenAll)
     print(io, "StopWhenAll with the Stopping Criteria:")
     for stopping_criterion in stop_when_all.criteria
         print(io, "\n     ")
-        replace(io, string(stopping_criterion), "\n" => "\n    ") #increase indent
+        replace(io, sprint(show, stopping_criterion; context = io), "\n" => "\n    ") #increase indent
     end
     return nothing
 end
@@ -207,7 +207,7 @@ function Base.show(io::IO, ::MIME"text/plain", stop_when_any::StopWhenAny)
     print(io, "StopWhenAny with the Stopping Criteria:")
     for stopping_criterion in stop_when_any.criteria
         print(io, "\n     ")
-        replace(io, string(stopping_criterion), "\n" => "\n    ") #increase indent
+        replace(io, sprint(show, stopping_criterion; context = io), "\n" => "\n    ") #increase indent
     end
     return nothing
 end

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -4,13 +4,12 @@ name = "AlgorithmsInterfaceTests"
 AlgorithmsInterface = "d1e3940c-cd12-4505-8585-b0a4b322527d"
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
-SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
+ParallelTestRunner = "d3525ed8-44d0-4b2c-a655-542cee43accc"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
-
-[compat]
-Aqua = "0.8"
-SafeTestsets = "0.1"
-Test = "1.10"
 
 [sources]
 AlgorithmsInterface = {path = ".."}
+
+[compat]
+Aqua = "0.8"
+Test = "1.10"

--- a/test/aqua.jl
+++ b/test/aqua.jl
@@ -1,0 +1,4 @@
+using AlgorithmsInterface
+using Aqua
+
+Aqua.test_all(AlgorithmsInterface)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,24 +1,23 @@
-using SafeTestsets, Test
+# Test entry point — uses ParallelTestRunner.jl to run test files in parallel
+# worker processes (auto-discovered from `test/`).
+#
+# Run locally:
+#   julia --project=test test/runtests.jl                  # run all tests
+#   julia --project=test test/runtests.jl --list           # list discovered test files
+#   julia --project=test test/runtests.jl --help           # show full usage
+#   julia --project=test test/runtests.jl <name> [<name>…] # only files whose
+#                                                          # name starts with <name>
+#
+# Or from the Julia REPL:
+#   using Pkg; Pkg.test("AlgorithmsInterface";
+#                       test_args=["--jobs=4", "--verbose"])
+#
+# Useful CLI options:
+#   --jobs=N      number of worker processes (default: chosen from CPU/memory)
+#   --verbose     print per-test timing, compile time, and memory stats
+#   --quickfail   abort the whole run on the first failure
 
-# these have to be included here to make show tests behave
+using ParallelTestRunner
 using AlgorithmsInterface
-using Dates
 
-@testset "AlgorithmsInterface.jl" begin
-    @safetestset "Newton" begin
-        include("newton.jl")
-    end
-
-    @safetestset "Stopping Criteria" begin
-        include("stopping_criterion.jl")
-    end
-
-    @safetestset "Logging Infrastructure" begin
-        include("logging.jl")
-    end
-
-    @safetestset "Aqua" begin
-        using AlgorithmsInterface, Aqua
-        Aqua.test_all(AlgorithmsInterface)
-    end
-end
+runtests(AlgorithmsInterface, ARGS)

--- a/test/stopping_criterion.jl
+++ b/test/stopping_criterion.jl
@@ -8,7 +8,7 @@ problem = AIT.DummyProblem()
 @testset "StopAfterIteration" begin
     s1 = StopAfterIteration(2)
     @test s1 isa StoppingCriterion
-    @test repr(s1) == "StopAfterIteration(2)"
+    @test repr(s1; context = :module => @__MODULE__) == "StopAfterIteration(2)"
     @test !indicates_convergence(s1)
     algorithm = AIT.DummyAlgorithm(s1)
     s1_state = initialize_state(problem, algorithm, s1)
@@ -26,7 +26,7 @@ end
 @testset "StopAfter" begin
     s1 = StopAfter(Nanosecond(7))
     @test s1 isa StoppingCriterion
-    @test string(s1) == "StopAfter(Nanosecond(7))"
+    @test sprint(show, s1; context = :module => @__MODULE__) == "StopAfter(Nanosecond(7))"
     @test_throws ArgumentError StopAfter(Second(-1))
 
     algorithm = AIT.DummyAlgorithm(s1)
@@ -53,7 +53,7 @@ end
     s1b = StopWhenAll([c1, c2])
     @test s1 == s1b
     @test s1 isa StoppingCriterion
-    @test sprint((io, x) -> show(io, MIME"text/plain"(), x), s1) ==
+    @test sprint((io, x) -> show(io, MIME"text/plain"(), x), s1; context = :module => @__MODULE__) ==
         "StopWhenAll with the Stopping Criteria:\n     StopAfterIteration(2)\n     StopAfter(Nanosecond(2))"
     algorithm = AIT.DummyAlgorithm(s1)
     s1_state = initialize_state(problem, algorithm, s1)
@@ -97,7 +97,7 @@ end
     s1 = c1 | c2
     @test s1 isa StoppingCriterion
     @test s1 == StopWhenAny([c1, c2])
-    @test sprint((io, x) -> show(io, MIME"text/plain"(), x), s1) ==
+    @test sprint((io, x) -> show(io, MIME"text/plain"(), x), s1; context = :module => @__MODULE__) ==
         "StopWhenAny with the Stopping Criteria:\n     StopAfterIteration(2)\n     StopAfter(Second(1))"
     @test !indicates_convergence(s1)
 


### PR DESCRIPTION
This is a minor change to alter the tests to use the ParallelTestRunner.jl interface.

To make this work, I also had to update the printing machinery slightly, since `string(x)` does not now about the context, so it would print types as if they are shown in the `Main` module, which doesn't necessarily have `AlgorithmsInterface` loaded.
This became visible here since ParallelTestRunner starts new processes to really isolate the tests, therefore you can't really control what is visible in `Main` (and `@eval Main using AlgorithmsInterface` feels very wrong 😉 )

Let me know if the explanation is clear enough, I'm happy to include a small readme file in the tests as well if you think that could be helpful