### PR TITLE
Stopping criterion updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,8 @@ docs/build
 docs/src/changelog.md
 *Manifest.toml
 
+# ParallelTestRunner logs
+test/test_*.log
+
 LocalPreferences.toml
 JuliaLocalPreferences.toml

--- a/Changelog.md
+++ b/Changelog.md
@@ -15,8 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   It recurses through nested combinations, so it separates stopping on a collapsed step size from stopping on an exhausted iteration budget — a distinction `indicates_convergence` is too coarse for.
 - Convenience two-argument `get_reason(algorithm, state)`, and likewise for `indicated_to_stop`, `indicates_convergence` and `get_active_stopping_criteria`, extracting the criterion and its state the way `is_finished` already did.
 - `StopReasonAction`, a `LoggingAction` that reports `get_reason` at the `:Stop` context.
-- Defaults for `get_reason` (`nothing`) and for the single-argument `indicates_convergence` (`false`), so a criterion that implements neither no longer hits a `MethodError` from the derived convergence reporting.
+- Defaults for `get_reason` (`nothing`) and for the type-domain `indicates_convergence` (`false`), so a criterion that implements neither no longer hits a `MethodError` from the derived convergence reporting.
 - Exports for `DefaultStoppingCriterionState`, `StopAfterTimePeriodState` and `GroupStoppingCriterionState`, which a downstream criterion is expected to reuse.
+
+### Changed
 
 ### Fixed
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,17 @@ All notable Changes to the Julia package `AlgorithmsInterface.jl` are documented
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.1] unreleased
+
+### Fixed
+
+- `indicates_convergence(::StoppingCriterion, ::StoppingCriterionState)` had its condition inverted, claiming convergence exactly when the criterion had *not* indicated to stop.
+- `indicates_convergence` for `StopWhenAll` and `StopWhenAny` now consults the children that actually indicated to stop.
+  Previously a `StopWhenAny` pairing a convergence criterion with a fallback such as `StopAfterIteration` could never report convergence, since the criteria-only variant is `all(indicates_convergence, criteria)`.
+- `is_finished!` for `StopWhenAll` and `StopWhenAny` short-circuited, skipping the children after the deciding one.
+  Stateful criteria were starved of the current iterate and their `at_iteration` left unset even when they did indicate to stop; every child is now updated once per iteration.
+- `get_reason` for `StopWhenAll` and `StopWhenAny` rendered children that had not indicated to stop as the literal text `"nothing"`.
+
 ## [0.1.0] 2026-05-01
 
 Initial release.

--- a/Changelog.md
+++ b/Changelog.md
@@ -9,16 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `indicated_to_stop(stopping_criterion, stopping_criterion_state)`, the machine-readable counterpart of `get_reason`, reporting whether a criterion became active during the current run.
+- `is_active(stopping_criterion, stopping_criterion_state)`, the machine-readable counterpart of `get_reason`, reporting whether a criterion became active during the current run.
   It defaults to reading the state's `at_iteration` and is what the generic convergence reporting is now built on, rather than `!isnothing(get_reason(...))`.
 - `get_active_stopping_criteria`, reporting which criteria became active.
   It recurses through nested combinations, so it separates stopping on a collapsed step size from stopping on an exhausted iteration budget — a distinction `indicates_convergence` is too coarse for.
-- Convenience two-argument `get_reason(algorithm, state)`, and likewise for `indicated_to_stop`, `indicates_convergence` and `get_active_stopping_criteria`, extracting the criterion and its state the way `is_finished` already did.
+- Convenience two-argument `get_reason(algorithm, state)`, and likewise for `is_active`, `indicates_convergence` and `get_active_stopping_criteria`, extracting the criterion and its state the way `is_finished` already did.
 - `StopReasonAction`, a `LoggingAction` that reports `get_reason` at the `:Stop` context.
 - Defaults for `get_reason` (`nothing`) and for the type-domain `indicates_convergence` (`false`), so a criterion that implements neither no longer hits a `MethodError` from the derived convergence reporting.
 - Exports for `DefaultStoppingCriterionState`, `StopAfterTimePeriodState` and `GroupStoppingCriterionState`, which a downstream criterion is expected to reuse.
 
 ### Changed
+
+- `indicates_convergence` without a state moved to the type domain: a new criterion implements `indicates_convergence(::Type{YourCriterion})`, and `indicates_convergence(criterion)` forwards to it.
+  `StopWhenAll` and `StopWhenAny` combine their children in the type domain as well, so a criterion that only implements the variant taking an instance is no longer accounted for in a group.
 
 ### Fixed
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.1.1] unreleased
 
+### Added
+
+- `indicated_to_stop(stopping_criterion, stopping_criterion_state)`, the machine-readable counterpart of `get_reason`, reporting whether a criterion became active during the current run.
+  It defaults to reading the state's `at_iteration` and is what the generic convergence reporting is now built on, rather than `!isnothing(get_reason(...))`.
+- `get_active_stopping_criteria`, reporting which criteria became active.
+  It recurses through nested combinations, so it separates stopping on a collapsed step size from stopping on an exhausted iteration budget — a distinction `indicates_convergence` is too coarse for.
+- Convenience two-argument `get_reason(algorithm, state)`, and likewise for `indicated_to_stop`, `indicates_convergence` and `get_active_stopping_criteria`, extracting the criterion and its state the way `is_finished` already did.
+- `StopReasonAction`, a `LoggingAction` that reports `get_reason` at the `:Stop` context.
+- Defaults for `get_reason` (`nothing`) and for the single-argument `indicates_convergence` (`false`), so a criterion that implements neither no longer hits a `MethodError` from the derived convergence reporting.
+- Exports for `DefaultStoppingCriterionState`, `StopAfterTimePeriodState` and `GroupStoppingCriterionState`, which a downstream criterion is expected to reuse.
+
 ### Fixed
 
 - `indicates_convergence(::StoppingCriterion, ::StoppingCriterionState)` had its condition inverted, claiming convergence exactly when the criterion had *not* indicated to stop.
@@ -14,7 +25,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Previously a `StopWhenAny` pairing a convergence criterion with a fallback such as `StopAfterIteration` could never report convergence, since the criteria-only variant is `all(indicates_convergence, criteria)`.
 - `is_finished!` for `StopWhenAll` and `StopWhenAny` short-circuited, skipping the children after the deciding one.
   Stateful criteria were starved of the current iterate and their `at_iteration` left unset even when they did indicate to stop; every child is now updated once per iteration.
-- `get_reason` for `StopWhenAll` and `StopWhenAny` rendered children that had not indicated to stop as the literal text `"nothing"`.
+- `get_reason` for `StopWhenAll` and `StopWhenAny` rendered children that had not indicated to stop as the literal text `"nothing"`, and returned `""` when no child had a message at all.
+  It now reports only the children that triggered, and `nothing` when there is nothing to report.
+- The non-mutating `is_finished` for `StopWhenAll` and `StopWhenAny` reset `at_iteration` at iteration `0`, contradicting its contract and silently clearing a group's recorded stop.
+- The non-mutating `is_finished` for `StopAfter` reported the elapsed time recorded by the last `is_finished!` rather than reading the clock, so it could answer "not finished" for a run long past its threshold.
+- `get_reason` for `StopAfterIteration` was gated on `at_iteration >= max_iterations` while its `Base.summary` was gated on `at_iteration >= 0`, so the two could disagree.
 
 ## [0.1.0] 2026-05-01
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AlgorithmsInterface"
 uuid = "d1e3940c-cd12-4505-8585-b0a4b322527d"
 authors = ["Ronny Bergmann <git@ronnybergmann.net>", "Lukas Devos <ldevos98@gmail.com>"]
-version = "0.1.0"
+version = "0.1.1"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/docs/src/logging.md
+++ b/docs/src/logging.md
@@ -136,6 +136,20 @@ nothing # hide
 Furthermore, specific algorithms could emit events for custom contexts too.
 We will come back to this in the section on the [`AlgorithmLogger`](@ref sec_algorithmlogger) design.
 
+### Reporting why we stopped
+
+The `:Stop` context is where the [stopping criterion](@ref sec_stopping) has its say, and [`StopReasonAction`](@ref) is a ready-made action that prints it:
+
+```@example Heron
+with_algorithmlogger(:Stop => StopReasonAction()) do
+    heron_sqrt(2.0)
+end
+nothing # hide
+```
+
+This is a thin wrapper around [`get_reason`](@ref), so anything that criterion reports shows up here.
+See [querying the verdict](@ref sec_stopping_verdict) for the machine-readable counterparts, which are useful in an [`IfAction`](@ref) predicate — for example to only dump diagnostics on a run that failed to converge.
+
 ### Timing execution
 
 Let's add timing information to see how long each iteration takes:
@@ -467,6 +481,7 @@ Implementing logging involves three main components:
 
 1. **LoggingAction**: Define what happens when a logging event occurs.
    * Use `CallbackAction` for quick inline functions.
+   * Use `StopReasonAction` at `:Stop` to report what made the algorithm stop.
    * Implement custom subtypes for reusable, stateful logging.
    * Implement `handle_message!(action, problem, algorithm, state; kwargs...)`.
 

--- a/docs/src/stopping_criterion.md
+++ b/docs/src/stopping_criterion.md
@@ -226,18 +226,18 @@ end
 Finally, we need to say what our criterion reports once it has triggered.
 There are two separate questions here, and keeping them apart is what makes the generic reporting work:
 
-* *Did* this criterion indicate to stop? This is answered by [`indicated_to_stop`](@ref), and it is what all the generic machinery is built on.
+* *Did* this criterion indicate to stop? This is answered by [`is_active`](@ref), and it is what all the generic machinery is built on.
 * Why, in words? This is answered by [`get_reason`](@ref), and it is for human consumption only.
 
 We get the first one for free.
-The default implementation of [`indicated_to_stop`](@ref) reads the `at_iteration` property of the state, and our `StopWhenStableState` has one, following the convention that a negative value means "has not (yet) indicated to stop".
-Only a state that records its status some other way has to implement [`indicated_to_stop`](@ref) itself.
+The default implementation of [`is_active`](@ref) reads the `at_iteration` property of the state, and our `StopWhenStableState` has one, following the convention that a negative value means "has not (yet) indicated to stop".
+Only a state that records its status some other way has to implement [`is_active`](@ref) itself.
 
 That leaves the message, plus the static statement that meeting this criterion *does* mean convergence:
 
 ```@example Heron
 function AlgorithmsInterface.get_reason(c::StopWhenStable, st::StopWhenStableState)
-    indicated_to_stop(c, st) || return nothing
+    is_active(c, st) || return nothing
     return "The algorithm reached an approximate stable point after $(st.at_iteration) iterations; the change $(st.delta) is less than $(c.tol).\n"
 end
 
@@ -249,7 +249,7 @@ Re-checking the predicate would make the message disappear again as soon as the 
 
 Only the type-domain [`indicates_convergence`](@ref) needs to be defined.
 It answers "would meeting this criterion mean the algorithm converged?", which is a static property of the criterion type alone.
-The variant taking a criterion simply forwards to the type, and the two-argument variant, which additionally answers "*did* it happen?", is derived from it and [`indicated_to_stop`](@ref):
+The variant taking a criterion simply forwards to the type, and the two-argument variant, which additionally answers "*did* it happen?", is derived from it and [`is_active`](@ref):
 
 ```@example Heron
 criterion = StopWhenStable(1e-8)
@@ -326,12 +326,12 @@ Implementing a criterion usually means defining:
 2. A state subtype of [`StoppingCriterionState`](@ref) capturing dynamic fields, including an `at_iteration` recording when the criterion triggered.
 3. `initialize_state` and `initialize_state!` for setup/reset.
 4. `is_finished!` (mutating) and optionally `is_finished` (non‑mutating) variants.
-5. `get_reason` (return `nothing` or a string) for user feedback, gated on `indicated_to_stop`.
+5. `get_reason` (return `nothing` or a string) for user feedback, gated on `is_active`.
 6. `indicates_convergence(::Type{YourCriterion})` to mark if meeting it implies convergence.
    The `(criterion,)` and the `(criterion, criterion_state)` variant are derived from this one and do not need to be defined.
 
 You may also implement `Base.summary(io, criterion, criterion_state)` for compact status reports,
-and `indicated_to_stop(criterion, criterion_state)` if your state does not record its status in an
+and `is_active(criterion, criterion_state)` if your state does not record its status in an
 `at_iteration` property.
 
 ## Reference API

--- a/docs/src/stopping_criterion.md
+++ b/docs/src/stopping_criterion.md
@@ -232,8 +232,24 @@ function AlgorithmsInterface.get_reason(c::StopWhenStable, st::StopWhenStableSta
     return "The algorithm reached an approximate stable point after $(st.at_iteration) iterations; the change $(st.delta) is less than $(c.tol)."
 end
 
-AlgorithmsInterface.indicates_convergence(c::StopWhenStable, st::StopWhenStableState) = true
+AlgorithmsInterface.indicates_convergence(c::StopWhenStable) = true
 ```
+
+Only the single-argument variant needs to be defined here.
+It answers "would meeting this criterion mean the algorithm converged?", which is a property of the criterion alone.
+The two-argument variant, which additionally answers "*did* it happen?", is derived from it and [`get_reason`](@ref), so implementing `get_reason` correctly is what makes convergence reporting work:
+
+```@example Heron
+criterion = StopWhenStable(1e-8)
+state = AlgorithmsInterface.initialize_state(SqrtProblem(16.0), HeronAlgorithm(criterion), criterion)
+indicates_convergence(criterion), indicates_convergence(criterion, state)
+```
+
+The criterion always *could* indicate convergence, but its fresh state has not yet seen it happen.
+
+This distinction matters most for composed criteria.
+A `StopWhenStable(1e-8) | StopAfterIteration(5)` can stop for either reason, so `indicates_convergence` of the group *without* a state is `false` — the group offers no guarantee.
+Given a state, it reports whether one of the children that actually triggered indicates convergence, which is what lets a caller tell "converged" apart from "ran out of iterations".
 
 ### Convergence in action
 
@@ -260,7 +276,11 @@ Implementing a criterion usually means defining:
 3. `initialize_state` and `initialize_state!` for setup/reset.
 4. `is_finished!` (mutating) and optionally `is_finished` (non‑mutating) variants.
 5. `get_reason` (return `nothing` or a string) for user feedback.
+   Returning `nothing` while the criterion has not triggered is what the two-argument
+   `indicates_convergence` relies on, so it is worth getting right.
 6. `indicates_convergence(::YourCriterion)` to mark if meeting it implies convergence.
+   The `(criterion, criterion_state)` variant is derived from this one and does not need to be
+   defined.
 
 You may also implement `Base.summary(io, criterion, criterion_state)` for compact status reports.
 

--- a/docs/src/stopping_criterion.md
+++ b/docs/src/stopping_criterion.md
@@ -13,7 +13,7 @@ Decoupling halting from stepping lets us:
 
 * Reuse generic stopping (iteration caps, time limits) across algorithms.
 * Compose multiple conditions (stop after 1 second OR 100 iterations, etc.).
-* Query convergence indication vs. mere forced termination.
+* Query convergence indication vs. mere forced termination, see [querying the verdict](@ref sec_stopping_verdict).
 * Store structured reasons and state (e.g. at which iteration a threshold was met).
 
 
@@ -223,21 +223,33 @@ end
 
 ### Reason and convergence reporting
 
-Finally, we need to implement [`get_reason`](@ref) and [`indicates_convergence`](@ref).
-These helper functions are required to interact with the [logging system](@ref sec_logging), to distinguish between states that are considered ongoing, stopped and converged, or stopped without convergence.
+Finally, we need to say what our criterion reports once it has triggered.
+There are two separate questions here, and keeping them apart is what makes the generic reporting work:
+
+* *Did* this criterion indicate to stop? This is answered by [`indicated_to_stop`](@ref), and it is what all the generic machinery is built on.
+* Why, in words? This is answered by [`get_reason`](@ref), and it is for human consumption only.
+
+We get the first one for free.
+The default implementation of [`indicated_to_stop`](@ref) reads the `at_iteration` property of the state, and our `StopWhenStableState` has one, following the convention that a negative value means "has not (yet) indicated to stop".
+Only a state that records its status some other way has to implement [`indicated_to_stop`](@ref) itself.
+
+That leaves the message, plus the static statement that meeting this criterion *does* mean convergence:
 
 ```@example Heron
 function AlgorithmsInterface.get_reason(c::StopWhenStable, st::StopWhenStableState)
-    (st.at_iteration >= 0 && st.delta < c.tol) || return nothing
-    return "The algorithm reached an approximate stable point after $(st.at_iteration) iterations; the change $(st.delta) is less than $(c.tol)."
+    indicated_to_stop(c, st) || return nothing
+    return "The algorithm reached an approximate stable point after $(st.at_iteration) iterations; the change $(st.delta) is less than $(c.tol).\n"
 end
 
 AlgorithmsInterface.indicates_convergence(c::StopWhenStable) = true
 ```
 
-Only the single-argument variant needs to be defined here.
+Note that `get_reason` gates on the *recorded* status rather than re-checking `st.delta < c.tol`.
+Re-checking the predicate would make the message disappear again as soon as the state moves on, whereas `at_iteration` is a permanent record of what happened.
+
+Only the single-argument [`indicates_convergence`](@ref) needs to be defined.
 It answers "would meeting this criterion mean the algorithm converged?", which is a property of the criterion alone.
-The two-argument variant, which additionally answers "*did* it happen?", is derived from it and [`get_reason`](@ref), so implementing `get_reason` correctly is what makes convergence reporting work:
+The two-argument variant, which additionally answers "*did* it happen?", is derived from it and [`indicated_to_stop`](@ref):
 
 ```@example Heron
 criterion = StopWhenStable(1e-8)
@@ -250,6 +262,43 @@ The criterion always *could* indicate convergence, but its fresh state has not y
 This distinction matters most for composed criteria.
 A `StopWhenStable(1e-8) | StopAfterIteration(5)` can stop for either reason, so `indicates_convergence` of the group *without* a state is `false` — the group offers no guarantee.
 Given a state, it reports whether one of the children that actually triggered indicates convergence, which is what lets a caller tell "converged" apart from "ran out of iterations".
+
+Both `get_reason` and the single-argument `indicates_convergence` have conservative defaults, `nothing` and `false`, so a criterion that has nothing to add does not have to implement them.
+
+### [Querying the verdict](@id sec_stopping_verdict)
+
+After a run, these same functions are how a caller finds out what happened.
+Since [`solve`](@ref) returns only the iterate, we use [`solve!`](@ref) with a state we hold on to:
+
+```@example Heron
+function heron_verdict(x, criterion)
+    problem = SqrtProblem(x)
+    algorithm = HeronAlgorithm(criterion)
+    state = AlgorithmsInterface.initialize_state(problem, algorithm)
+    solve!(problem, algorithm, state)
+    return (;
+        converged = indicates_convergence(algorithm, state),
+        reason = get_reason(algorithm, state),
+        active = [typeof(c) for (c, cs) in get_active_stopping_criteria(algorithm, state)],
+    )
+end
+
+heron_verdict(16.0, StopWhenStable(1e-8) | StopAfterIteration(50))
+```
+
+These two-argument forms extract the criterion and its state for us, so there is no need to reach into `algorithm.stopping_criterion` and `state.stopping_criterion_state` by hand.
+
+The very same criterion reports a different verdict when the budget is what runs out first:
+
+```@example Heron
+heron_verdict(16.0, StopWhenStable(1e-8) | StopAfterIteration(5))
+```
+
+This is the distinction the whole two-argument machinery exists for.
+Note also that convergence is a coarse verdict: an iteration cap and a collapsed step size both fail to indicate convergence while calling for quite different responses.
+That is what [`get_active_stopping_criteria`](@ref) is for — it reports exactly which criteria became active, recursing through any [`StopWhenAll`](@ref) and [`StopWhenAny`](@ref) so that the groups themselves never show up.
+
+The [logging system](@ref sec_logging) offers [`StopReasonAction`](@ref) to report the reason at the `:Stop` context, without having to hold on to the state at all.
 
 ### Convergence in action
 
@@ -272,17 +321,19 @@ heron_sqrt(16.0; stopping_criterion = criterion)
 Implementing a criterion usually means defining:
 
 1. A subtype of [`StoppingCriterion`](@ref).
-2. A state subtype of [`StoppingCriterionState`](@ref) capturing dynamic fields.
+2. A state subtype of [`StoppingCriterionState`](@ref) capturing dynamic fields, including an
+   `at_iteration` recording when the criterion triggered.
 3. `initialize_state` and `initialize_state!` for setup/reset.
 4. `is_finished!` (mutating) and optionally `is_finished` (non‑mutating) variants.
-5. `get_reason` (return `nothing` or a string) for user feedback.
-   Returning `nothing` while the criterion has not triggered is what the two-argument
-   `indicates_convergence` relies on, so it is worth getting right.
+5. `get_reason` (return `nothing` or a string) for user feedback, gated on
+   `indicated_to_stop`.
 6. `indicates_convergence(::YourCriterion)` to mark if meeting it implies convergence.
    The `(criterion, criterion_state)` variant is derived from this one and does not need to be
    defined.
 
-You may also implement `Base.summary(io, criterion, criterion_state)` for compact status reports.
+You may also implement `Base.summary(io, criterion, criterion_state)` for compact status reports,
+and `indicated_to_stop(criterion, criterion_state)` if your state does not record its status in an
+`at_iteration` property.
 
 ## Reference API
 

--- a/docs/src/stopping_criterion.md
+++ b/docs/src/stopping_criterion.md
@@ -275,12 +275,14 @@ function heron_verdict(x, criterion)
     problem = SqrtProblem(x)
     algorithm = HeronAlgorithm(criterion)
     state = AlgorithmsInterface.initialize_state(problem, algorithm)
+
     solve!(problem, algorithm, state)
-    return (;
-        converged = indicates_convergence(algorithm, state),
-        reason = get_reason(algorithm, state),
-        active = [typeof(c) for (c, cs) in get_active_stopping_criteria(algorithm, state)],
-    )
+
+    converged = indicates_convergence(algorithm, state)
+    reason = get_reason(algorithm, state)
+    active = [typeof(c) for (c, cs) in get_active_stopping_criteria(algorithm, state)]
+
+    return converged, reason, active
 end
 
 heron_verdict(16.0, StopWhenStable(1e-8) | StopAfterIteration(50))

--- a/docs/src/stopping_criterion.md
+++ b/docs/src/stopping_criterion.md
@@ -241,15 +241,15 @@ function AlgorithmsInterface.get_reason(c::StopWhenStable, st::StopWhenStableSta
     return "The algorithm reached an approximate stable point after $(st.at_iteration) iterations; the change $(st.delta) is less than $(c.tol).\n"
 end
 
-AlgorithmsInterface.indicates_convergence(c::StopWhenStable) = true
+AlgorithmsInterface.indicates_convergence(::Type{StopWhenStable}) = true
 ```
 
 Note that `get_reason` gates on the *recorded* status rather than re-checking `st.delta < c.tol`.
 Re-checking the predicate would make the message disappear again as soon as the state moves on, whereas `at_iteration` is a permanent record of what happened.
 
-Only the single-argument [`indicates_convergence`](@ref) needs to be defined.
-It answers "would meeting this criterion mean the algorithm converged?", which is a property of the criterion alone.
-The two-argument variant, which additionally answers "*did* it happen?", is derived from it and [`indicated_to_stop`](@ref):
+Only the type-domain [`indicates_convergence`](@ref) needs to be defined.
+It answers "would meeting this criterion mean the algorithm converged?", which is a static property of the criterion type alone.
+The variant taking a criterion simply forwards to the type, and the two-argument variant, which additionally answers "*did* it happen?", is derived from it and [`indicated_to_stop`](@ref):
 
 ```@example Heron
 criterion = StopWhenStable(1e-8)
@@ -260,10 +260,10 @@ indicates_convergence(criterion), indicates_convergence(criterion, state)
 The criterion always *could* indicate convergence, but its fresh state has not yet seen it happen.
 
 This distinction matters most for composed criteria.
-A `StopWhenStable(1e-8) | StopAfterIteration(5)` can stop for either reason, so `indicates_convergence` of the group *without* a state is `false` — the group offers no guarantee.
+A `StopWhenStable(1e-8) | StopAfterIteration(5)` can stop for either reason, so `indicates_convergence` of the group *without* a state is `false` since the group offers no guarantee.
 Given a state, it reports whether one of the children that actually triggered indicates convergence, which is what lets a caller tell "converged" apart from "ran out of iterations".
 
-Both `get_reason` and the single-argument `indicates_convergence` have conservative defaults, `nothing` and `false`, so a criterion that has nothing to add does not have to implement them.
+Both `get_reason` and the type-domain `indicates_convergence` have conservative defaults, `nothing` and `false`, so a criterion that has nothing to add does not have to implement them.
 
 ### [Querying the verdict](@id sec_stopping_verdict)
 
@@ -323,15 +323,12 @@ heron_sqrt(16.0; stopping_criterion = criterion)
 Implementing a criterion usually means defining:
 
 1. A subtype of [`StoppingCriterion`](@ref).
-2. A state subtype of [`StoppingCriterionState`](@ref) capturing dynamic fields, including an
-   `at_iteration` recording when the criterion triggered.
+2. A state subtype of [`StoppingCriterionState`](@ref) capturing dynamic fields, including an `at_iteration` recording when the criterion triggered.
 3. `initialize_state` and `initialize_state!` for setup/reset.
 4. `is_finished!` (mutating) and optionally `is_finished` (non‑mutating) variants.
-5. `get_reason` (return `nothing` or a string) for user feedback, gated on
-   `indicated_to_stop`.
-6. `indicates_convergence(::YourCriterion)` to mark if meeting it implies convergence.
-   The `(criterion, criterion_state)` variant is derived from this one and does not need to be
-   defined.
+5. `get_reason` (return `nothing` or a string) for user feedback, gated on `indicated_to_stop`.
+6. `indicates_convergence(::Type{YourCriterion})` to mark if meeting it implies convergence.
+   The `(criterion,)` and the `(criterion, criterion_state)` variant are derived from this one and do not need to be defined.
 
 You may also implement `Base.summary(io, criterion, criterion_state)` for compact status reports,
 and `indicated_to_stop(criterion, criterion_state)` if your state does not record its status in an

--- a/src/AlgorithmsInterface.jl
+++ b/src/AlgorithmsInterface.jl
@@ -32,11 +32,13 @@ export step!, solve, solve!, solve_loop!
 # stopping criteria
 export StoppingCriterion, StoppingCriterionState
 export StopAfter, StopAfterIteration, StopWhenAll, StopWhenAny
+export DefaultStoppingCriterionState, StopAfterTimePeriodState, GroupStoppingCriterionState
 
 export is_finished, is_finished!, get_reason, indicated_to_stop, indicates_convergence
+export get_active_stopping_criteria
 
 # Logging interface
-export LoggingAction, CallbackAction, IfAction, ActionGroup
+export LoggingAction, CallbackAction, IfAction, ActionGroup, StopReasonAction
 export with_algorithmlogger, emit_message
 
 end # module AlgorithmsInterface

--- a/src/AlgorithmsInterface.jl
+++ b/src/AlgorithmsInterface.jl
@@ -34,7 +34,7 @@ export StoppingCriterion, StoppingCriterionState
 export StopAfter, StopAfterIteration, StopWhenAll, StopWhenAny
 export DefaultStoppingCriterionState, StopAfterTimePeriodState, GroupStoppingCriterionState
 
-export is_finished, is_finished!, get_reason, indicated_to_stop, indicates_convergence
+export is_finished, is_finished!, get_reason, is_active, indicates_convergence
 export get_active_stopping_criteria
 
 # Logging interface

--- a/src/AlgorithmsInterface.jl
+++ b/src/AlgorithmsInterface.jl
@@ -33,7 +33,7 @@ export step!, solve, solve!, solve_loop!
 export StoppingCriterion, StoppingCriterionState
 export StopAfter, StopAfterIteration, StopWhenAll, StopWhenAny
 
-export is_finished, is_finished!, get_reason, indicates_convergence
+export is_finished, is_finished!, get_reason, indicated_to_stop, indicates_convergence
 
 # Logging interface
 export LoggingAction, CallbackAction, IfAction, ActionGroup

--- a/src/logging.jl
+++ b/src/logging.jl
@@ -84,6 +84,41 @@ function handle_message!(
         nothing
 end
 
+"""
+    StopReasonAction(io::IO = stdout; prefix::String = "")
+
+Concrete [`LoggingAction`](@ref) that reports why an algorithm stopped, by printing
+[`get_reason`](@ref) of its [`StoppingCriterion`](@ref) prefixed by `prefix`.
+
+This is intended for the `:Stop` context:
+
+```julia
+with_algorithmlogger(:Stop => StopReasonAction()) do
+    solve(problem, algorithm)
+end
+```
+
+Nothing is printed while no criterion has indicated to stop, so registering this on another
+context is harmless.
+
+See also [`indicates_convergence`](@ref) to distinguish stopping because of convergence from
+merely running out of budget, and [`get_active_stopping_criteria`](@ref) to inspect which
+criteria became active.
+"""
+struct StopReasonAction <: LoggingAction
+    io::IO
+    prefix::String
+end
+StopReasonAction(io::IO = stdout; prefix::String = "") = StopReasonAction(io, prefix)
+
+function handle_message!(
+        action::StopReasonAction, ::Problem, algorithm::Algorithm, state::State; kwargs...
+    )
+    reason = get_reason(algorithm, state)
+    isnothing(reason) || print(action.io, action.prefix, reason)
+    return nothing
+end
+
 # Algorithm Logger
 # ----------------
 """

--- a/src/stopping_criterion.jl
+++ b/src/stopping_criterion.jl
@@ -198,6 +198,16 @@ struct StopWhenAll{TCriteria <: Tuple} <: StoppingCriterion
     StopWhenAll(c::StoppingCriterion...) = new{typeof(c)}(c)
 end
 StopWhenAll(c::AbstractVector{<:StoppingCriterion}) = StopWhenAll(c...)
+
+@doc """
+    indicates_convergence(stop_when_all::StopWhenAll)
+
+A [`StopWhenAll`](@ref) indicates convergence whenever *one* of its criteria does.
+
+Since it can only indicate to stop once every one of its criteria does, a single criterion that
+allows to conclude convergence is enough to conclude it for the group as a whole.
+Note how this is the opposite quantifier from [`StopWhenAny`](@ref).
+"""
 function indicates_convergence(stop_when_all::StopWhenAll)
     return any(indicates_convergence, stop_when_all.criteria)
 end
@@ -249,6 +259,19 @@ struct StopWhenAny{TCriteria <: Tuple} <: StoppingCriterion
 end
 StopWhenAny(c::AbstractVector{<:StoppingCriterion}) = StopWhenAny(c...)
 
+@doc """
+    indicates_convergence(stop_when_any::StopWhenAny)
+
+A [`StopWhenAny`](@ref) indicates convergence only when *all* of its criteria do.
+
+Since any single one of its criteria can make it indicate to stop, the group offers no guarantee
+unless every criterion it is composed of allows to conclude convergence on its own.
+Note how this is the opposite quantifier from [`StopWhenAll`](@ref).
+
+This is deliberately pessimistic, and is why a `tolerance | budget` combination is never
+convergent as a criterion. To ask whether a *particular run* stopped because the convergence
+criterion is what triggered, pass the accompanying [`GroupStoppingCriterionState`](@ref) as well.
+"""
 function indicates_convergence(stop_when_any::StopWhenAny)
     return all(indicates_convergence, stop_when_any.criteria)
 end
@@ -304,13 +327,19 @@ function get_reason(
         stop_when::Union{StopWhenAll, StopWhenAny},
         stopping_criterion_states::GroupStoppingCriterionState,
     )
-    stopping_criterion_states.at_iteration < 0 && return nothing
-    reasons = Iterators.map(
-        get_reason, stop_when.criteria, stopping_criterion_states.criteria_states
+    indicated_to_stop(stop_when, stopping_criterion_states) || return nothing
+    # only the children that did indicate to stop have anything to report, and of those the ones
+    # without a message return `nothing`, which `join` would render as the literal text "nothing"
+    reasons = (
+        get_reason(stopping_criterion, stopping_criterion_state) for
+            (stopping_criterion, stopping_criterion_state) in
+            zip(stop_when.criteria, stopping_criterion_states.criteria_states)
+            if indicated_to_stop(stopping_criterion, stopping_criterion_state)
     )
-    # children that did not indicate to stop return `nothing` and are left out entirely,
-    # since `join` would otherwise render them as the literal text "nothing"
-    return join(Iterators.filter(!isnothing, reasons))
+    reason = join(Iterators.filter(!isnothing, reasons))
+    # a group that indicated to stop but collected no message at all has nothing to say either,
+    # and must not report the empty string, which would read as a message to any consumer
+    return isempty(reason) ? nothing : reason
 end
 
 @doc """
@@ -329,7 +358,7 @@ function indicates_convergence(
         stop_when::Union{StopWhenAll, StopWhenAny},
         stopping_criterion_states::GroupStoppingCriterionState,
     )
-    stopping_criterion_states.at_iteration < 0 && return false
+    indicated_to_stop(stop_when, stopping_criterion_states) || return false
     return any(
         st -> indicates_convergence(st[1], st[2]),
         zip(stop_when.criteria, stopping_criterion_states.criteria_states),
@@ -436,7 +465,7 @@ function Base.summary(
         io::IO,
         stop_when_any::StopWhenAny, stopping_criterion_states::GroupStoppingCriterionState,
     )
-    has_stopped = (stopping_criterion_states.at_iteration >= 0)
+    has_stopped = indicated_to_stop(stop_when_any, stopping_criterion_states)
     s = has_stopped ? "reached" : "not reached"
     r = "Stop when _one_ of the following are fulfilled:\n"
     for (stopping_criterion, stopping_criterion_state) in
@@ -450,7 +479,7 @@ function Base.summary(
         io::IO,
         stop_when_all::StopWhenAll, stopping_criterion_states::GroupStoppingCriterionState,
     )
-    has_stopped = (stopping_criterion_states.at_iteration >= 0)
+    has_stopped = indicated_to_stop(stop_when_all, stopping_criterion_states)
     s = has_stopped ? "reached" : "not reached"
     r = "Stop when _all_ of the following are fulfilled:\n"
     for (stopping_criterion, stopping_criterion_state) in

--- a/src/stopping_criterion.jl
+++ b/src/stopping_criterion.jl
@@ -14,12 +14,11 @@ It should usually implement
 * [`initialize_state!`](@ref)`(problem, algorithm, stopping_criterion)`
 * [`initialize_state`](@ref)`(problem, algorithm, stopping_criterion)`
 * [`get_reason`](@ref)`(stopping_criterion, stopping_criterion_state)`
-* [`indicates_convergence`](@ref)`(stopping_criterion, [stopping_criterion_state])`
+* [`indicates_convergence`](@ref)`(::Type{<:StoppingCriterion})`
 
-Note that only the single-argument [`indicates_convergence`](@ref) has to be implemented:
-it answers whether meeting this criterion *would* mean convergence, which is a property of the
-criterion alone. The variant that additionally takes a [`StoppingCriterionState`](@ref) answers
-whether it *did* happen and can be derived.
+Note that only [`indicates_convergence`](@ref) has to be implemented:
+it answers whether meeting this criterion *would* mean convergence, which is a static property of the criterion type alone.
+Both the variant taking a criterion and the one that additionally takes a [`StoppingCriterionState`](@ref), answering whether it *did* happen are derived from it.
 """
 abstract type StoppingCriterion end
 
@@ -84,16 +83,20 @@ indicated_to_stop(algorithm::Algorithm, state::State) =
     indicated_to_stop(algorithm.stopping_criterion, state.stopping_criterion_state)
 
 @doc """
+    indicates_convergence(::Type{<:StoppingCriterion})
     indicates_convergence(stopping_criterion::StoppingCriterion)
 
 Return whether or not a [`StoppingCriterion`](@ref) indicates convergence.
 
 This is a static property of the criterion itself and independent of any run:
 it answers whether meeting this criterion *would* allow to conclude that the algorithm converged.
+Since it does not depend on the values a criterion is configured with, it is answered in the type domain, and a new criterion should implement the variant taking the type.
 The default is `false`, which is the conservative answer for a criterion that makes no such promise,
 for example a budget such as [`StopAfterIteration`](@ref).
 """
-indicates_convergence(stopping_criterion::StoppingCriterion) = false
+indicates_convergence(::Type{<:StoppingCriterion}) = false
+
+indicates_convergence(stopping_criterion::StoppingCriterion) = indicates_convergence(typeof(stopping_criterion))
 
 @doc """
     indicates_convergence(stopping_criterion::StoppingCriterion, ::StoppingCriterionState)
@@ -230,7 +233,7 @@ end
 StopWhenAll(c::AbstractVector{<:StoppingCriterion}) = StopWhenAll(c...)
 
 @doc """
-    indicates_convergence(stop_when_all::StopWhenAll)
+    indicates_convergence(::Type{<:StopWhenAll})
 
 A [`StopWhenAll`](@ref) indicates convergence whenever *one* of its criteria does.
 
@@ -238,8 +241,8 @@ Since it can only indicate to stop once every one of its criteria does, a single
 allows to conclude convergence is enough to conclude it for the group as a whole.
 Note how this is the opposite quantifier from [`StopWhenAny`](@ref).
 """
-function indicates_convergence(stop_when_all::StopWhenAll)
-    return any(indicates_convergence, stop_when_all.criteria)
+function indicates_convergence(::Type{StopWhenAll{TCriteria}}) where {TCriteria <: Tuple}
+    return any(indicates_convergence, fieldtypes(TCriteria))
 end
 
 function Base.show(io::IO, ::MIME"text/plain", stop_when_all::StopWhenAll)
@@ -290,7 +293,7 @@ end
 StopWhenAny(c::AbstractVector{<:StoppingCriterion}) = StopWhenAny(c...)
 
 @doc """
-    indicates_convergence(stop_when_any::StopWhenAny)
+    indicates_convergence(::Type{<:StopWhenAny})
 
 A [`StopWhenAny`](@ref) indicates convergence only when *all* of its criteria do.
 
@@ -302,8 +305,8 @@ This is deliberately pessimistic, and is why a `tolerance | budget` combination 
 convergent as a criterion. To ask whether a *particular run* stopped because the convergence
 criterion is what triggered, pass the accompanying [`GroupStoppingCriterionState`](@ref) as well.
 """
-function indicates_convergence(stop_when_any::StopWhenAny)
-    return all(indicates_convergence, stop_when_any.criteria)
+function indicates_convergence(::Type{StopWhenAny{TCriteria}}) where {TCriteria <: Tuple}
+    return all(indicates_convergence, fieldtypes(TCriteria))
 end
 
 function Base.show(io::IO, ::MIME"text/plain", stop_when_any::StopWhenAny)
@@ -377,7 +380,7 @@ end
 
 Return whether a group of stopping criteria stopped because of convergence.
 
-Unlike the single-argument variant, which can only reason about the criteria themselves, this
+Unlike the variant without a state, which can only reason about the criteria types themselves, this
 consults the accompanying [`StoppingCriterionState`](@ref)s and therefore only takes the
 children that actually indicated to stop into account. A group indicates convergence as soon as
 *one* of those children does, so a [`StopWhenAny`](@ref) combining a convergence criterion with a

--- a/src/stopping_criterion.jl
+++ b/src/stopping_criterion.jl
@@ -38,7 +38,7 @@ property, and provide corresponding `getproperty` and `setproperty!` methods.
   means that it has not (yet) indicated to stop.
 
 A state that records its status differently can instead implement
-[`indicated_to_stop`](@ref)`(stopping_criterion, stopping_criterion_state)`.
+[`is_active`](@ref)`(stopping_criterion, stopping_criterion_state)`.
 """
 abstract type StoppingCriterionState end
 
@@ -55,7 +55,7 @@ Reasons are concatenated when several criteria are combined and are printed verb
 should end in a newline.
 
 This is meant for human consumption only. To decide programmatically whether a criterion
-indicated to stop, use [`indicated_to_stop`](@ref) instead.
+indicated to stop, use [`is_active`](@ref) instead.
 The default returns `nothing`, so a criterion that has no message to provide does not have to implement this.
 """
 get_reason(::StoppingCriterion, ::StoppingCriterionState) = nothing
@@ -64,23 +64,23 @@ get_reason(algorithm::Algorithm, state::State) =
     get_reason(algorithm.stopping_criterion, state.stopping_criterion_state)
 
 @doc """
-    indicated_to_stop(stopping_criterion::StoppingCriterion, stopping_criterion_state::StoppingCriterionState)
-    indicated_to_stop(algorithm::Algorithm, state::State)
+    is_active(stopping_criterion::StoppingCriterion, stopping_criterion_state::StoppingCriterionState)
+    is_active(algorithm::Algorithm, state::State)
 
-Return whether a [`StoppingCriterion`](@ref) in the given [`StoppingCriterionState`](@ref) has
-indicated to stop, that is whether it became active during the current run.
+Return whether a [`StoppingCriterion`](@ref) in the given [`StoppingCriterionState`](@ref) is
+active, that is whether it has indicated to stop during the current run.
 The second variant extracts the criterion and its state from `algorithm` and `state`.
 
 This is the machine-readable counterpart of [`get_reason`](@ref) and the predicate the generic convergence reporting is built on.
 The default implementation reads the `at_iteration` property of the state, see [`StoppingCriterionState`](@ref),
 so it only has to be implemented for a state that records its status differently.
 """
-indicated_to_stop(
+is_active(
     ::StoppingCriterion, stopping_criterion_state::StoppingCriterionState
 ) = stopping_criterion_state.at_iteration >= 0
 
-indicated_to_stop(algorithm::Algorithm, state::State) =
-    indicated_to_stop(algorithm.stopping_criterion, state.stopping_criterion_state)
+is_active(algorithm::Algorithm, state::State) =
+    is_active(algorithm.stopping_criterion, state.stopping_criterion_state)
 
 @doc """
     indicates_convergence(::Type{<:StoppingCriterion})
@@ -112,7 +112,7 @@ since the algorithm has then not yet stopped.
 function indicates_convergence(
         stopping_criterion::StoppingCriterion, stopping_criterion_state::StoppingCriterionState,
     )
-    return indicated_to_stop(stopping_criterion, stopping_criterion_state) &&
+    return is_active(stopping_criterion, stopping_criterion_state) &&
         indicates_convergence(stopping_criterion)
 end
 
@@ -186,8 +186,8 @@ end
     get_active_stopping_criteria(stopping_criterion::StoppingCriterion, stopping_criterion_state::StoppingCriterionState)
     get_active_stopping_criteria(algorithm::Algorithm, state::State)
 
-Return all `(stopping_criterion, stopping_criterion_state)` pairs that [`indicated_to_stop`](@ref),
-as a vector.
+Return all `(stopping_criterion, stopping_criterion_state)` pairs for which the criterion
+[`is_active`](@ref), as a vector.
 The variant with two arguments extracts the criterion and its state from `algorithm` and `state`.
 
 Meta criteria such as [`StopWhenAll`](@ref) and [`StopWhenAny`](@ref) are recursed into and do not
@@ -204,7 +204,7 @@ function get_active_stopping_criteria(
         stopping_criterion_state::StoppingCriterionState,
     )
     pairs = Tuple{StoppingCriterion, StoppingCriterionState}[]
-    indicated_to_stop(stopping_criterion, stopping_criterion_state) &&
+    is_active(stopping_criterion, stopping_criterion_state) &&
         push!(pairs, (stopping_criterion, stopping_criterion_state))
     return pairs
 end
@@ -360,14 +360,14 @@ function get_reason(
         stop_when::Union{StopWhenAll, StopWhenAny},
         stopping_criterion_states::GroupStoppingCriterionState,
     )
-    indicated_to_stop(stop_when, stopping_criterion_states) || return nothing
+    is_active(stop_when, stopping_criterion_states) || return nothing
     # only the children that did indicate to stop have anything to report, and of those the ones
     # without a message return `nothing`, which `join` would render as the literal text "nothing"
     reasons = (
         get_reason(stopping_criterion, stopping_criterion_state) for
             (stopping_criterion, stopping_criterion_state) in
             zip(stop_when.criteria, stopping_criterion_states.criteria_states)
-            if indicated_to_stop(stopping_criterion, stopping_criterion_state)
+            if is_active(stopping_criterion, stopping_criterion_state)
     )
     reason = join(Iterators.filter(!isnothing, reasons))
     # a group that indicated to stop but collected no message at all has nothing to say either,
@@ -391,7 +391,7 @@ function indicates_convergence(
         stop_when::Union{StopWhenAll, StopWhenAny},
         stopping_criterion_states::GroupStoppingCriterionState,
     )
-    indicated_to_stop(stop_when, stopping_criterion_states) || return false
+    is_active(stop_when, stopping_criterion_states) || return false
     return any(
         st -> indicates_convergence(st[1], st[2]),
         zip(stop_when.criteria, stopping_criterion_states.criteria_states),
@@ -509,7 +509,7 @@ function Base.summary(
         io::IO,
         stop_when_any::StopWhenAny, stopping_criterion_states::GroupStoppingCriterionState,
     )
-    has_stopped = indicated_to_stop(stop_when_any, stopping_criterion_states)
+    has_stopped = is_active(stop_when_any, stopping_criterion_states)
     s = has_stopped ? "reached" : "not reached"
     r = "Stop when _one_ of the following are fulfilled:\n"
     for (stopping_criterion, stopping_criterion_state) in
@@ -523,7 +523,7 @@ function Base.summary(
         io::IO,
         stop_when_all::StopWhenAll, stopping_criterion_states::GroupStoppingCriterionState,
     )
-    has_stopped = indicated_to_stop(stop_when_all, stopping_criterion_states)
+    has_stopped = is_active(stop_when_all, stopping_criterion_states)
     s = has_stopped ? "reached" : "not reached"
     r = "Stop when _all_ of the following are fulfilled:\n"
     for (stopping_criterion, stopping_criterion_state) in
@@ -609,7 +609,7 @@ function get_reason(
         stop_after_iteration::StopAfterIteration,
         stopping_criterion_state::DefaultStoppingCriterionState,
     )
-    if indicated_to_stop(stop_after_iteration, stopping_criterion_state)
+    if is_active(stop_after_iteration, stopping_criterion_state)
         return "At iteration $(stopping_criterion_state.at_iteration) the algorithm reached its maximal number of iterations ($(stop_after_iteration.max_iterations)).\n"
     end
     return nothing
@@ -619,7 +619,7 @@ function Base.summary(
         stop_after_iteration::StopAfterIteration,
         stopping_criterion_state::DefaultStoppingCriterionState,
     )
-    has_stopped = indicated_to_stop(stop_after_iteration, stopping_criterion_state)
+    has_stopped = is_active(stop_after_iteration, stopping_criterion_state)
     s = has_stopped ? "reached" : "not reached"
     return print(io, "Max Iterations ($(stop_after_iteration.max_iterations)): $s")
 end
@@ -721,7 +721,7 @@ function get_reason(
         stop_after::StopAfter,
         stopping_criterion_state::StopAfterTimePeriodState,
     )
-    if indicated_to_stop(stop_after, stopping_criterion_state)
+    if is_active(stop_after, stopping_criterion_state)
         return "After iteration $(stopping_criterion_state.at_iteration) the algorithm ran for $(floor(stopping_criterion_state.time, typeof(stop_after.threshold))) (threshold: $(stop_after.threshold)).\n"
     end
     return nothing
@@ -730,7 +730,7 @@ function Base.summary(
         io::IO,
         stop_after::StopAfter, stopping_criterion_state::StopAfterTimePeriodState,
     )
-    has_stopped = indicated_to_stop(stop_after, stopping_criterion_state)
+    has_stopped = is_active(stop_after, stopping_criterion_state)
     s = has_stopped ? "reached" : "not reached"
     return print(io, "stopped after $(stop_after.threshold): $s")
 end

--- a/src/stopping_criterion.jl
+++ b/src/stopping_criterion.jl
@@ -179,6 +179,36 @@ function Base.summary(
     return String(take!(io))
 end
 
+@doc """
+    get_active_stopping_criteria(stopping_criterion::StoppingCriterion, stopping_criterion_state::StoppingCriterionState)
+    get_active_stopping_criteria(algorithm::Algorithm, state::State)
+
+Return all `(stopping_criterion, stopping_criterion_state)` pairs that [`indicated_to_stop`](@ref),
+as a vector.
+The variant with two arguments extracts the criterion and its state from `algorithm` and `state`.
+
+Meta criteria such as [`StopWhenAll`](@ref) and [`StopWhenAny`](@ref) are recursed into and do not
+appear themselves, so the result only contains the criteria that actually became active.
+This lets a caller distinguish *why* an algorithm stopped, which is more fine grained than
+[`indicates_convergence`](@ref): stopping because a step size collapsed and stopping because an
+iteration budget ran out both fail to indicate convergence, but usually warrant different action.
+
+The default treats a criterion as a leaf, so a new criterion that itself combines others has to
+implement this to be recursed into.
+"""
+function get_active_stopping_criteria(
+        stopping_criterion::StoppingCriterion,
+        stopping_criterion_state::StoppingCriterionState,
+    )
+    pairs = Tuple{StoppingCriterion, StoppingCriterionState}[]
+    indicated_to_stop(stopping_criterion, stopping_criterion_state) &&
+        push!(pairs, (stopping_criterion, stopping_criterion_state))
+    return pairs
+end
+
+get_active_stopping_criteria(algorithm::Algorithm, state::State) =
+    get_active_stopping_criteria(algorithm.stopping_criterion, state.stopping_criterion_state)
+
 #
 #
 # Meta StoppingCriteria
@@ -363,6 +393,23 @@ function indicates_convergence(
         st -> indicates_convergence(st[1], st[2]),
         zip(stop_when.criteria, stopping_criterion_states.criteria_states),
     )
+end
+
+function get_active_stopping_criteria(
+        stop_when::Union{StopWhenAll, StopWhenAny},
+        stopping_criterion_states::GroupStoppingCriterionState,
+    )
+    pairs = Tuple{StoppingCriterion, StoppingCriterionState}[]
+    # recurse rather than report the group itself: `&` and `|` flatten, but a mixed combination
+    # such as `(c1 | c2) & c3` genuinely nests
+    for (stopping_criterion, stopping_criterion_state) in
+        zip(stop_when.criteria, stopping_criterion_states.criteria_states)
+        append!(
+            pairs,
+            get_active_stopping_criteria(stopping_criterion, stopping_criterion_state),
+        )
+    end
+    return pairs
 end
 
 function initialize_state(

--- a/src/stopping_criterion.jl
+++ b/src/stopping_criterion.jl
@@ -9,10 +9,17 @@ A concrete [`StoppingCriterion`](@ref) should also implement an
 
 It should usually implement
 
-* [`indicates_convergence`](@ref)`(stopping_criterion)`
-* [`indicates_convergence`](@ref)`(stopping_criterion, stopping_criterion_state)`
 * [`is_finished!`](@ref)`(problem, algorithm, state, stopping_criterion, stopping_criterion_state)`
 * [`is_finished`](@ref)`(problem, algorithm, state, stopping_criterion, stopping_criterion_state)`
+* [`initialize_state!`](@ref)`(problem, algorithm, stopping_criterion)`
+* [`initialize_state`](@ref)`(problem, algorithm, stopping_criterion)`
+* [`get_reason`](@ref)`(stopping_criterion, stopping_criterion_state)`
+* [`indicates_convergence`](@ref)`(stopping_criterion, [stopping_criterion_state])`
+
+Note that only the single-argument [`indicates_convergence`](@ref) has to be implemented:
+it answers whether meeting this criterion *would* mean convergence, which is a property of the
+criterion alone. The variant that additionally takes a [`StoppingCriterionState`](@ref) answers
+whether it *did* happen and can be derived.
 """
 abstract type StoppingCriterion end
 
@@ -22,39 +29,79 @@ abstract type StoppingCriterion end
 An abstract type to represent a stopping criterion state within a [`State`](@ref).
 It represents the concrete state a [`StoppingCriterion`](@ref) is in.
 
-It should usually implement
+## Properties
 
-* [`get_reason`](@ref)`(stopping_criterion, stopping_criterion_state)`
-* [`indicates_convergence`](@ref)`(stopping_criterion, stopping_criterion_state)`
-* [`is_finished!`](@ref)`(problem, algorithm, state, stopping_criterion, stopping_criterion_state)`
-* [`is_finished`](@ref)`(problem, algorithm, state, stopping_criterion, stopping_criterion_state)`
+In order for the generic convergence reporting to work, the state should contain the following
+property, and provide corresponding `getproperty` and `setproperty!` methods.
+
+* `at_iteration` – the iteration at which the accompanying [`StoppingCriterion`](@ref) indicated
+  to stop, where `0` means it already indicated to stop at the start and any negative number
+  means that it has not (yet) indicated to stop.
+
+A state that records its status differently can instead implement
+[`indicated_to_stop`](@ref)`(stopping_criterion, stopping_criterion_state)`.
 """
 abstract type StoppingCriterionState end
 
-function get_reason end
 @doc """
     get_reason(stopping_criterion::StoppingCriterion, stopping_criterion_state::StoppingCriterionState)
+    get_reason(algorithm::Algorithm, state::State)
 
 Provide a reason in human readable text as to why a [`StoppingCriterion`](@ref) with [`StoppingCriterionState`](@ref) indicated to stop.
 If it does not indicate to stop, this should return `nothing`.
+The second variant extracts the criterion and its state from `algorithm` and `state`.
 
 Providing the iteration at which this indicated to stop in the reason would be preferable.
-"""
-get_reason(::StoppingCriterion, ::StoppingCriterionState)
+Reasons are concatenated when several criteria are combined and are printed verbatim, so they
+should end in a newline.
 
-function indicates_convergence end
+This is meant for human consumption only. To decide programmatically whether a criterion
+indicated to stop, use [`indicated_to_stop`](@ref) instead.
+The default returns `nothing`, so a criterion that has no message to provide does not have to implement this.
+"""
+get_reason(::StoppingCriterion, ::StoppingCriterionState) = nothing
+
+get_reason(algorithm::Algorithm, state::State) =
+    get_reason(algorithm.stopping_criterion, state.stopping_criterion_state)
+
+@doc """
+    indicated_to_stop(stopping_criterion::StoppingCriterion, stopping_criterion_state::StoppingCriterionState)
+    indicated_to_stop(algorithm::Algorithm, state::State)
+
+Return whether a [`StoppingCriterion`](@ref) in the given [`StoppingCriterionState`](@ref) has
+indicated to stop, that is whether it became active during the current run.
+The second variant extracts the criterion and its state from `algorithm` and `state`.
+
+This is the machine-readable counterpart of [`get_reason`](@ref) and the predicate the generic convergence reporting is built on.
+The default implementation reads the `at_iteration` property of the state, see [`StoppingCriterionState`](@ref),
+so it only has to be implemented for a state that records its status differently.
+"""
+indicated_to_stop(
+    ::StoppingCriterion, stopping_criterion_state::StoppingCriterionState
+) = stopping_criterion_state.at_iteration >= 0
+
+indicated_to_stop(algorithm::Algorithm, state::State) =
+    indicated_to_stop(algorithm.stopping_criterion, state.stopping_criterion_state)
+
 @doc """
     indicates_convergence(stopping_criterion::StoppingCriterion)
 
 Return whether or not a [`StoppingCriterion`](@ref) indicates convergence.
+
+This is a static property of the criterion itself and independent of any run:
+it answers whether meeting this criterion *would* allow to conclude that the algorithm converged.
+The default is `false`, which is the conservative answer for a criterion that makes no such promise,
+for example a budget such as [`StopAfterIteration`](@ref).
 """
-indicates_convergence(stopping_criterion::StoppingCriterion)
+indicates_convergence(stopping_criterion::StoppingCriterion) = false
 
 @doc """
     indicates_convergence(stopping_criterion::StoppingCriterion, ::StoppingCriterionState)
+    indicates_convergence(algorithm::Algorithm, state::State)
 
 Return whether or not a [`StoppingCriterion`](@ref) indicates convergence when it is in [`StoppingCriterionState`](@ref),
 i.e. also check whether the state indicates that the criterion has been active.
+The second variant extracts the criterion and its state from `algorithm` and `state`.
 
 If so it returns whether `stopping_criterion` itself indicates convergence, otherwise it returns `false`,
 since the algorithm has then not yet stopped.
@@ -62,8 +109,12 @@ since the algorithm has then not yet stopped.
 function indicates_convergence(
         stopping_criterion::StoppingCriterion, stopping_criterion_state::StoppingCriterionState,
     )
-    return !isnothing(get_reason(stopping_criterion, stopping_criterion_state)) && indicates_convergence(stopping_criterion)
+    return indicated_to_stop(stopping_criterion, stopping_criterion_state) &&
+        indicates_convergence(stopping_criterion)
 end
+
+indicates_convergence(algorithm::Algorithm, state::State) =
+    indicates_convergence(algorithm.stopping_criterion, state.stopping_criterion_state)
 
 _doc_is_finished = """
     is_finished(problem::Problem, algorithm::Algorithm, state::State)
@@ -71,13 +122,12 @@ _doc_is_finished = """
     is_finished!(problem::Problem, algorithm::Algorithm, state::State)
     is_finished!(problem::Problem, algorithm::Algorithm, state::State, stopping_criterion::StoppingCriterion, stopping_criterion_state::StoppingCriterionState)
 
-Indicate whether an [`Algorithm`](@ref) solving [`Problem`](@ref) is finished having reached
-a certain [`State`](@ref). The variant with three arguments by default extracts the
-[`StoppingCriterion`](@ref) and its [`StoppingCriterionState`](@ref) and their actual
-checks are performed in the implementation with five arguments.
+Indicate whether an [`Algorithm`](@ref) solving [`Problem`](@ref) is finished having reached a certain [`State`](@ref).
+The variant with three arguments by default extracts the [`StoppingCriterion`](@ref) and its [`StoppingCriterionState`](@ref)
+and their actual checks are performed in the implementation with five arguments.
 
-The mutating variant does alter the `stopping_criterion_state` and should only be called
-once per iteration, the other one merely inspects the current status without mutation.
+The mutating variant alters the `stopping_criterion_state` and is only called once per iteration,
+the other one merely inspects the current status without mutation.
 """
 
 @doc "$(_doc_is_finished)"
@@ -486,18 +536,17 @@ function get_reason(
         stop_after_iteration::StopAfterIteration,
         stopping_criterion_state::DefaultStoppingCriterionState,
     )
-    if stopping_criterion_state.at_iteration >= stop_after_iteration.max_iterations
+    if indicated_to_stop(stop_after_iteration, stopping_criterion_state)
         return "At iteration $(stopping_criterion_state.at_iteration) the algorithm reached its maximal number of iterations ($(stop_after_iteration.max_iterations)).\n"
     end
     return nothing
 end
-indicates_convergence(stop_after_iteration::StopAfterIteration) = false
 function Base.summary(
         io::IO,
         stop_after_iteration::StopAfterIteration,
         stopping_criterion_state::DefaultStoppingCriterionState,
     )
-    has_stopped = (stopping_criterion_state.at_iteration >= 0)
+    has_stopped = indicated_to_stop(stop_after_iteration, stopping_criterion_state)
     s = has_stopped ? "reached" : "not reached"
     return print(io, "Max Iterations ($(stop_after_iteration.max_iterations)): $s")
 end
@@ -597,7 +646,7 @@ function get_reason(
         stop_after::StopAfter,
         stopping_criterion_state::StopAfterTimePeriodState,
     )
-    if (stopping_criterion_state.at_iteration >= 0)
+    if indicated_to_stop(stop_after, stopping_criterion_state)
         return "After iteration $(stopping_criterion_state.at_iteration) the algorithm ran for $(floor(stopping_criterion_state.time, typeof(stop_after.threshold))) (threshold: $(stop_after.threshold)).\n"
     end
     return nothing
@@ -606,8 +655,7 @@ function Base.summary(
         io::IO,
         stop_after::StopAfter, stopping_criterion_state::StopAfterTimePeriodState,
     )
-    has_stopped = (stopping_criterion_state.at_iteration >= 0)
+    has_stopped = indicated_to_stop(stop_after, stopping_criterion_state)
     s = has_stopped ? "reached" : "not reached"
     return print(io, "stopped after $(stop_after.threshold): $s")
 end
-indicates_convergence(stop_after::StopAfter) = false

--- a/src/stopping_criterion.jl
+++ b/src/stopping_criterion.jl
@@ -62,7 +62,7 @@ since the algorithm has then not yet stopped.
 function indicates_convergence(
         stopping_criterion::StoppingCriterion, stopping_criterion_state::StoppingCriterionState,
     )
-    return isnothing(get_reason(stopping_criterion, stopping_criterion_state)) && indicates_convergence(stopping_criterion)
+    return !isnothing(get_reason(stopping_criterion, stopping_criterion_state)) && indicates_convergence(stopping_criterion)
 end
 
 _doc_is_finished = """
@@ -255,9 +255,35 @@ function get_reason(
         stopping_criterion_states::GroupStoppingCriterionState,
     )
     stopping_criterion_states.at_iteration < 0 && return nothing
-    criteria = stop_when.criteria
-    stopping_criterion_states = stopping_criterion_states.criteria_states
-    return join(Iterators.map(get_reason, criteria, stopping_criterion_states))
+    reasons = Iterators.map(
+        get_reason, stop_when.criteria, stopping_criterion_states.criteria_states
+    )
+    # children that did not indicate to stop return `nothing` and are left out entirely,
+    # since `join` would otherwise render them as the literal text "nothing"
+    return join(Iterators.filter(!isnothing, reasons))
+end
+
+@doc """
+    indicates_convergence(stop_when::Union{StopWhenAll, StopWhenAny}, ::GroupStoppingCriterionState)
+
+Return whether a group of stopping criteria stopped because of convergence.
+
+Unlike the single-argument variant, which can only reason about the criteria themselves, this
+consults the accompanying [`StoppingCriterionState`](@ref)s and therefore only takes the
+children that actually indicated to stop into account. A group indicates convergence as soon as
+*one* of those children does, so a [`StopWhenAny`](@ref) combining a convergence criterion with a
+fallback such as [`StopAfterIteration`](@ref) still reports convergence whenever the convergence
+criterion is what triggered.
+"""
+function indicates_convergence(
+        stop_when::Union{StopWhenAll, StopWhenAny},
+        stopping_criterion_states::GroupStoppingCriterionState,
+    )
+    stopping_criterion_states.at_iteration < 0 && return false
+    return any(
+        st -> indicates_convergence(st[1], st[2]),
+        zip(stop_when.criteria, stopping_criterion_states.criteria_states),
+    )
 end
 
 function initialize_state(
@@ -307,10 +333,14 @@ function is_finished!(
     )
     k = state.iteration
     (k == 0) && (stopping_criterion_states.at_iteration = -1) # reset on init
-    if all(
-            st -> is_finished!(problem, algorithm, state, st[1], st[2]),
-            zip(stop_when_all.criteria, stopping_criterion_states.criteria_states),
-        )
+    # `map` rather than `all`, so that every child is updated exactly once per iteration:
+    # `all` would short-circuit and starve stateful criteria of the current iterate
+    finished = map(
+        stop_when_all.criteria, stopping_criterion_states.criteria_states
+    ) do stopping_criterion, stopping_criterion_state
+        is_finished!(problem, algorithm, state, stopping_criterion, stopping_criterion_state)
+    end
+    if all(finished)
         stopping_criterion_states.at_iteration = k
         return true
     end
@@ -337,10 +367,15 @@ function is_finished!(
     )
     k = state.iteration
     (k == 0) && (stopping_criterion_states.at_iteration = -1) # reset on init
-    if any(
-            st -> is_finished!(problem, algorithm, state, st[1], st[2]),
-            zip(stop_when_any.criteria, stopping_criterion_states.criteria_states),
-        )
+    # `map` rather than `any`, so that every child is updated exactly once per iteration:
+    # `any` would short-circuit and starve stateful criteria of the current iterate, and
+    # leave their `at_iteration` unset even though they did indicate to stop
+    finished = map(
+        stop_when_any.criteria, stopping_criterion_states.criteria_states
+    ) do stopping_criterion, stopping_criterion_state
+        is_finished!(problem, algorithm, state, stopping_criterion, stopping_criterion_state)
+    end
+    if any(finished)
         stopping_criterion_states.at_iteration = k
         return true
     end

--- a/src/stopping_criterion.jl
+++ b/src/stopping_criterion.jl
@@ -396,15 +396,12 @@ function is_finished(
         problem::Problem, algorithm::Algorithm, state::State,
         stop_when_all::StopWhenAll, stopping_criterion_states::GroupStoppingCriterionState,
     )
-    k = state.iteration
-    (k == 0) && (stopping_criterion_states.at_iteration = -1) # reset on init
-    if all(
-            st -> is_finished(problem, algorithm, state, st[1], st[2]),
-            zip(stop_when_all.criteria, stopping_criterion_states.criteria_states),
-        )
-        return true
-    end
-    return false
+    # short-circuiting is fine here: unlike `is_finished!`, this may not mutate, so there is no
+    # child left starved of an update by not being asked
+    return all(
+        st -> is_finished(problem, algorithm, state, st[1], st[2]),
+        zip(stop_when_all.criteria, stopping_criterion_states.criteria_states),
+    )
 end
 function is_finished!(
         problem::Problem, algorithm::Algorithm, state::State,
@@ -430,15 +427,12 @@ function is_finished(
         problem::Problem, algorithm::Algorithm, state::State,
         stop_when_any::StopWhenAny, stopping_criterion_states::GroupStoppingCriterionState,
     )
-    k = state.iteration
-    (k == 0) && (stopping_criterion_states.at_iteration = -1) # reset on init
-    if any(
-            st -> is_finished(problem, algorithm, state, st[1], st[2]),
-            zip(stop_when_any.criteria, stopping_criterion_states.criteria_states),
-        )
-        return true
-    end
-    return false
+    # short-circuiting is fine here: unlike `is_finished!`, this may not mutate, so there is no
+    # child left starved of an update by not being asked
+    return any(
+        st -> is_finished(problem, algorithm, state, st[1], st[2]),
+        zip(stop_when_any.criteria, stopping_criterion_states.criteria_states),
+    )
 end
 function is_finished!(
         problem::Problem, algorithm::Algorithm, state::State,
@@ -650,8 +644,10 @@ function is_finished(
         stop_after::StopAfter, stop_after_state::StopAfterTimePeriodState,
     )
     k = state.iteration
-    # Just check whether the (last recorded) time is beyond the threshold
-    return (k > 0 && (stop_after_state.time > Nanosecond(stop_after.threshold)))
+    # Read the clock rather than the `time` recorded by the last `is_finished!`, so that this
+    # reports on the time elapsed *now*. Only the timer itself may not be (re)started here.
+    (k <= 0 || value(stop_after_state.start) == 0) && return false
+    return (Nanosecond(time_ns()) - stop_after_state.start) > Nanosecond(stop_after.threshold)
 end
 function is_finished!(
         ::Problem, ::Algorithm, state::State,

--- a/test/logging.jl
+++ b/test/logging.jl
@@ -124,6 +124,26 @@ end
     end
 end
 
+@testset "StopReasonAction reports why the algorithm stopped" begin
+    problem = LogDummyProblem()
+    algorithm = LogDummyAlgorithm(StopAfterIteration(3))
+
+    io = IOBuffer()
+    with_algorithmlogger(:Stop => StopReasonAction(io; prefix = "Stopped: ")) do
+        solve(problem, algorithm)
+    end
+    reason = String(take!(io))
+    @test startswith(reason, "Stopped: At iteration 3")
+
+    # nothing is reported while no criterion has indicated to stop, so registering the action on
+    # another context is harmless
+    io = IOBuffer()
+    with_algorithmlogger(:Start => StopReasonAction(io)) do
+        solve(problem, algorithm)
+    end
+    @test isempty(String(take!(io)))
+end
+
 @testset "Global logging toggle disables all logging" begin
     problem = LogDummyProblem()
     algorithm = LogDummyAlgorithm(StopAfterIteration(3))

--- a/test/newton.jl
+++ b/test/newton.jl
@@ -14,7 +14,6 @@ end
 
 struct NewtonMethod{S} <: Algorithm
     stopping_criterion::S
-    # TODO: logging settings? stopping criterium initialization?
 end
 
 mutable struct NewtonState{S} <: State

--- a/test/stopping_criterion.jl
+++ b/test/stopping_criterion.jl
@@ -1,9 +1,83 @@
 using Test
 using AlgorithmsInterface
 using AlgorithmsInterface: Test as AIT
+using AlgorithmsInterface: DefaultStoppingCriterionState
 using Dates
 
 problem = AIT.DummyProblem()
+
+# Helper criteria
+# ---------------
+# `StopAfterIteration` and `StopAfter` both have `indicates_convergence == false`, so neither can
+# exercise the convergence-versus-fallback logic. This one does.
+struct StopWhenConverged <: StoppingCriterion
+    at::Int
+end
+AlgorithmsInterface.initialize_state(::Problem, ::Algorithm, ::StopWhenConverged; kwargs...) =
+    DefaultStoppingCriterionState()
+function AlgorithmsInterface.initialize_state!(
+        ::Problem, ::Algorithm, ::StopWhenConverged,
+        stopping_criterion_state::DefaultStoppingCriterionState; kwargs...,
+    )
+    stopping_criterion_state.at_iteration = -1
+    return stopping_criterion_state
+end
+function AlgorithmsInterface.is_finished(
+        ::Problem, ::Algorithm, state::State,
+        stop_when_converged::StopWhenConverged, ::DefaultStoppingCriterionState,
+    )
+    return state.iteration >= stop_when_converged.at
+end
+function AlgorithmsInterface.is_finished!(
+        ::Problem, ::Algorithm, state::State,
+        stop_when_converged::StopWhenConverged,
+        stopping_criterion_state::DefaultStoppingCriterionState,
+    )
+    k = state.iteration
+    (k == 0) && (stopping_criterion_state.at_iteration = -1)
+    if k >= stop_when_converged.at
+        stopping_criterion_state.at_iteration = k
+        return true
+    end
+    return false
+end
+function AlgorithmsInterface.get_reason(
+        ::StopWhenConverged, stopping_criterion_state::DefaultStoppingCriterionState,
+    )
+    stopping_criterion_state.at_iteration < 0 && return nothing
+    return "Converged at iteration $(stopping_criterion_state.at_iteration).\n"
+end
+AlgorithmsInterface.indicates_convergence(::StopWhenConverged) = true
+
+# Never indicates to stop, but records how many times it was asked, so that short-circuiting
+# inside the meta criteria becomes observable.
+struct CountingCriterion <: StoppingCriterion end
+mutable struct CountingCriterionState <: StoppingCriterionState
+    at_iteration::Int
+    calls::Int
+end
+AlgorithmsInterface.initialize_state(::Problem, ::Algorithm, ::CountingCriterion; kwargs...) =
+    CountingCriterionState(-1, 0)
+function AlgorithmsInterface.initialize_state!(
+        ::Problem, ::Algorithm, ::CountingCriterion,
+        stopping_criterion_state::CountingCriterionState; kwargs...,
+    )
+    stopping_criterion_state.at_iteration = -1
+    stopping_criterion_state.calls = 0
+    return stopping_criterion_state
+end
+AlgorithmsInterface.is_finished(
+    ::Problem, ::Algorithm, ::State, ::CountingCriterion, ::CountingCriterionState
+) = false
+function AlgorithmsInterface.is_finished!(
+        ::Problem, ::Algorithm, ::State, ::CountingCriterion,
+        stopping_criterion_state::CountingCriterionState,
+    )
+    stopping_criterion_state.calls += 1
+    return false
+end
+AlgorithmsInterface.get_reason(::CountingCriterion, ::CountingCriterionState) = nothing
+AlgorithmsInterface.indicates_convergence(::CountingCriterion) = false
 
 @testset "StopAfterIteration" begin
     s1 = StopAfterIteration(2)
@@ -126,4 +200,82 @@ end
     @test s1 | c3 == s2
     @test c1 | (c2 | c3) == s2
     @test s1 | s2 isa StopWhenAny
+end
+
+@testset "indicates_convergence with a state" begin
+    converging = StopWhenConverged(2)
+    fallback = StopAfterIteration(5)
+
+    # A criterion that has not indicated to stop has not converged, whatever it would report
+    # once it does.
+    algorithm = AIT.DummyAlgorithm(converging)
+    scs = initialize_state(problem, algorithm, converging)
+    @test indicates_convergence(converging)
+    @test !indicates_convergence(converging, scs)
+    state = AIT.DummyState(nothing, scs, 1)
+    @test !is_finished!(problem, algorithm, state)
+    @test !indicates_convergence(converging, scs)
+    state.iteration = 2
+    @test is_finished!(problem, algorithm, state)
+    @test indicates_convergence(converging, scs)
+
+    # `tol | maxiter`: the criteria-only variant is unconditionally `false`, because
+    # `indicates_convergence(::StopWhenAny) = all(...)` and the fallback never converges.
+    # The state-aware variant has to distinguish the two ways of stopping.
+    stop_when = converging | fallback
+    @test !indicates_convergence(stop_when)
+
+    algorithm = AIT.DummyAlgorithm(stop_when)
+    scs = initialize_state(problem, algorithm, stop_when)
+    state = AIT.DummyState(nothing, scs, 0)
+    @test !is_finished!(problem, algorithm, state)
+    @test !indicates_convergence(stop_when, scs)
+
+    state.iteration = 2
+    @test is_finished!(problem, algorithm, state)
+    @test indicates_convergence(stop_when, scs)
+    @test indicates_convergence(converging, scs.criteria_states[1])
+    @test !indicates_convergence(fallback, scs.criteria_states[2])
+
+    # only the fallback triggers -> stopped, but not converged
+    stop_when = StopWhenConverged(100) | fallback
+    algorithm = AIT.DummyAlgorithm(stop_when)
+    scs = initialize_state(problem, algorithm, stop_when)
+    state = AIT.DummyState(nothing, scs, 0)
+    @test !is_finished!(problem, algorithm, state)
+    state.iteration = 5
+    @test is_finished!(problem, algorithm, state)
+    @test !indicates_convergence(stop_when, scs)
+
+    # and the reason mentions the fallback only -- children that returned `nothing` must not be
+    # rendered as the literal text "nothing"
+    reason = get_reason(stop_when, scs)
+    @test startswith(reason, "At iteration 5")
+    @test !contains(reason, "nothing")
+end
+
+@testset "is_finished! does not short-circuit" begin
+    counter = CountingCriterion()
+
+    # `StopWhenAny`: the first child already indicates to stop
+    stop_when = StopAfterIteration(1) | counter
+    algorithm = AIT.DummyAlgorithm(stop_when)
+    scs = initialize_state(problem, algorithm, stop_when)
+    state = AIT.DummyState(nothing, scs, 1)
+    @test is_finished!(problem, algorithm, state)
+    @test scs.criteria_states[2].calls == 1
+
+    # `StopWhenAll`: the first child already indicates *not* to stop
+    stop_when = counter & StopAfterIteration(1)
+    algorithm = AIT.DummyAlgorithm(stop_when)
+    scs = initialize_state(problem, algorithm, stop_when)
+    state = AIT.DummyState(nothing, scs, 1)
+    @test !is_finished!(problem, algorithm, state)
+    @test scs.criteria_states[1].calls == 1
+    @test !is_finished!(problem, algorithm, state)
+    @test scs.criteria_states[1].calls == 2
+
+    # a reset clears the tally again
+    initialize_state!(problem, algorithm, stop_when, scs)
+    @test scs.criteria_states[1].calls == 0
 end

--- a/test/stopping_criterion.jl
+++ b/test/stopping_criterion.jl
@@ -46,7 +46,7 @@ function AlgorithmsInterface.get_reason(
     stopping_criterion_state.at_iteration < 0 && return nothing
     return "Converged at iteration $(stopping_criterion_state.at_iteration).\n"
 end
-AlgorithmsInterface.indicates_convergence(::StopWhenConverged) = true
+AlgorithmsInterface.indicates_convergence(::Type{StopWhenConverged}) = true
 
 # Never indicates to stop, but records how many times it was asked, so that short-circuiting
 # inside the meta criteria becomes observable.
@@ -76,7 +76,7 @@ function AlgorithmsInterface.is_finished!(
     return false
 end
 AlgorithmsInterface.get_reason(::CountingCriterion, ::CountingCriterionState) = nothing
-AlgorithmsInterface.indicates_convergence(::CountingCriterion) = false
+AlgorithmsInterface.indicates_convergence(::Type{CountingCriterion}) = false
 
 # Indicates to stop immediately, but implements nothing beyond the bare minimum: no `get_reason`
 # and no `indicates_convergence`, so it exercises the fallbacks for both.
@@ -119,7 +119,7 @@ end
 AlgorithmsInterface.indicated_to_stop(
     ::UnconventionalCriterion, stopping_criterion_state::UnconventionalCriterionState
 ) = stopping_criterion_state.stopped
-AlgorithmsInterface.indicates_convergence(::UnconventionalCriterion) = true
+AlgorithmsInterface.indicates_convergence(::Type{UnconventionalCriterion}) = true
 
 @testset "StopAfterIteration" begin
     s1 = StopAfterIteration(2)
@@ -281,7 +281,7 @@ end
     @test indicates_convergence(converging, scs)
 
     # `tol | maxiter`: the criteria-only variant is unconditionally `false`, because
-    # `indicates_convergence(::StopWhenAny) = all(...)` and the fallback never converges.
+    # `indicates_convergence(::Type{<:StopWhenAny}) = all(...)` and the fallback never converges.
     # The state-aware variant has to distinguish the two ways of stopping.
     stop_when = converging | fallback
     @test !indicates_convergence(stop_when)

--- a/test/stopping_criterion.jl
+++ b/test/stopping_criterion.jl
@@ -1,7 +1,6 @@
 using Test
 using AlgorithmsInterface
 using AlgorithmsInterface: Test as AIT
-using AlgorithmsInterface: DefaultStoppingCriterionState
 using Dates
 
 problem = AIT.DummyProblem()
@@ -430,4 +429,53 @@ end
     @test scs.at_iteration == at_iteration
     @test map(cs -> cs.at_iteration, scs.criteria_states) == child_at_iterations
     @test indicates_convergence(stop_when, scs)
+end
+
+@testset "get_active_stopping_criteria" begin
+    converging = StopWhenConverged(2)
+    budget = StopAfterIteration(2)
+    # a threshold this small is exceeded by any real elapsed time, so the timer triggers on the
+    # first iteration after it was started
+    timer = StopAfter(Nanosecond(1))
+
+    # `&` and `|` flatten, but a mixed combination genuinely nests, and the recursion has to
+    # report the active leaves rather than the groups
+    stop_when = (converging | budget) & timer
+    algorithm = AIT.DummyAlgorithm(stop_when)
+    scs = initialize_state(problem, algorithm, stop_when)
+    state = AIT.DummyState(nothing, scs, 0)
+
+    @test isempty(get_active_stopping_criteria(algorithm, state))
+    # iteration 0 starts the timer
+    @test !is_finished!(problem, algorithm, state)
+    state.iteration = 2
+    @test is_finished!(problem, algorithm, state)
+
+    active = get_active_stopping_criteria(algorithm, state)
+    @test map(first, active) == [converging, budget, timer]
+    @test all(((c, cs),) -> indicated_to_stop(c, cs), active)
+    # the groups themselves are recursed into, not reported
+    @test !any(c -> c isa Union{StopWhenAll, StopWhenAny}, map(first, active))
+
+    # only the criteria that did indicate to stop are listed
+    stop_when = StopWhenConverged(100) | budget
+    algorithm = AIT.DummyAlgorithm(stop_when)
+    scs = initialize_state(problem, algorithm, stop_when)
+    state = AIT.DummyState(nothing, scs, 2)
+    @test is_finished!(problem, algorithm, state)
+    @test map(first, get_active_stopping_criteria(algorithm, state)) == [budget]
+end
+
+@testset "convenience accessors" begin
+    stop_when = StopWhenConverged(2) | StopAfterIteration(5)
+    algorithm = AIT.DummyAlgorithm(stop_when)
+    scs = initialize_state(problem, algorithm, stop_when)
+    state = AIT.DummyState(nothing, scs, 2)
+    @test is_finished!(problem, algorithm, state)
+
+    @test get_reason(algorithm, state) == get_reason(stop_when, scs)
+    @test indicated_to_stop(algorithm, state) == indicated_to_stop(stop_when, scs)
+    @test indicates_convergence(algorithm, state) == indicates_convergence(stop_when, scs)
+    @test get_active_stopping_criteria(algorithm, state) ==
+        get_active_stopping_criteria(stop_when, scs)
 end

--- a/test/stopping_criterion.jl
+++ b/test/stopping_criterion.jl
@@ -163,13 +163,20 @@ end
     @test !is_finished!(problem, algorithm, alg_state)
     @test !is_finished(problem, algorithm, alg_state)
     @test isnothing(get_reason(s1, s1_state))
-    # Fake stop
-    s1_state.time = Nanosecond(9)
+    # The threshold is small enough that any real elapsed time exceeds it
     alg_state.iteration = 2
     @test is_finished!(problem, algorithm, alg_state)
     @test is_finished(problem, algorithm, alg_state)
     @test startswith(get_reason(s1, s1_state), "After iteration 2")
     @test endswith(summary(s1, s1_state), ": reached")
+
+    # The non-mutating variant reads the clock rather than the `time` recorded by the last
+    # `is_finished!`, so a stale recording does not make it report "not finished"
+    s1_state.time = Nanosecond(0)
+    @test is_finished(problem, algorithm, alg_state)
+    # but it may not (re)start the timer either, so it stays quiet before the first iteration
+    alg_state.iteration = 0
+    @test !is_finished(problem, algorithm, alg_state)
 end
 
 @testset "StopWhenAll" begin
@@ -239,7 +246,9 @@ end
     alg_state = AIT.DummyState(nothing, s1_state, 1)
     @test !is_finished!(problem, algorithm, alg_state)
     @test !is_finished(problem, algorithm, alg_state)
-    s1_state.criteria_states[2].time = Second(2)
+    # Fake two seconds of elapsed time by moving the recorded start into the past -- the
+    # non-mutating variant derives the elapsed time from the clock, not from `time`
+    s1_state.criteria_states[2].start = Nanosecond(time_ns()) - Nanosecond(Second(2))
     @test is_finished(problem, algorithm, alg_state)
     alg_state.iteration = 2
     @test is_finished(problem, algorithm, alg_state)
@@ -401,4 +410,24 @@ end
     state = AIT.DummyState(nothing, scs, 1)
     @test is_finished!(problem, algorithm, state)
     @test get_reason(stop_when, scs) == "Converged at iteration 1.\n"
+end
+
+@testset "is_finished does not mutate" begin
+    # The non-mutating variant only inspects, so a recorded stop has to survive it -- including
+    # at iteration 0, where the mutating variant does reset.
+    stop_when = StopWhenConverged(2) | StopAfterIteration(5)
+    algorithm = AIT.DummyAlgorithm(stop_when)
+    scs = initialize_state(problem, algorithm, stop_when)
+    state = AIT.DummyState(nothing, scs, 2)
+
+    @test is_finished!(problem, algorithm, state)
+    at_iteration = scs.at_iteration
+    child_at_iterations = map(cs -> cs.at_iteration, scs.criteria_states)
+    @test at_iteration == 2
+
+    state.iteration = 0
+    is_finished(problem, algorithm, state)
+    @test scs.at_iteration == at_iteration
+    @test map(cs -> cs.at_iteration, scs.criteria_states) == child_at_iterations
+    @test indicates_convergence(stop_when, scs)
 end

--- a/test/stopping_criterion.jl
+++ b/test/stopping_criterion.jl
@@ -102,7 +102,7 @@ function AlgorithmsInterface.is_finished!(
 end
 
 # Records its status somewhere other than `at_iteration`, so it has to override
-# `indicated_to_stop` rather than rely on the default.
+# `is_active` rather than rely on the default.
 struct UnconventionalCriterion <: StoppingCriterion end
 mutable struct UnconventionalCriterionState <: StoppingCriterionState
     stopped::Bool
@@ -116,7 +116,7 @@ function AlgorithmsInterface.initialize_state!(
     stopping_criterion_state.stopped = false
     return stopping_criterion_state
 end
-AlgorithmsInterface.indicated_to_stop(
+AlgorithmsInterface.is_active(
     ::UnconventionalCriterion, stopping_criterion_state::UnconventionalCriterionState
 ) = stopping_criterion_state.stopped
 AlgorithmsInterface.indicates_convergence(::Type{UnconventionalCriterion}) = true
@@ -138,7 +138,7 @@ AlgorithmsInterface.indicates_convergence(::Type{UnconventionalCriterion}) = tru
     @test startswith(get_reason(s1, s1_state), "At iteration 2")
     @test endswith(summary(s1, s1_state), ": reached")
 
-    # `get_reason` and `summary` are both gated on `indicated_to_stop`, so they agree even for
+    # `get_reason` and `summary` are both gated on `is_active`, so they agree even for
     # an `at_iteration` below `max_iterations`
     s2 = StopAfterIteration(10)
     s2_state = initialize_state(problem, AIT.DummyAlgorithm(s2), s2)
@@ -341,36 +341,36 @@ end
     @test scs.criteria_states[1].calls == 0
 end
 
-@testset "indicated_to_stop" begin
+@testset "is_active" begin
     converging = StopWhenConverged(2)
     algorithm = AIT.DummyAlgorithm(converging)
     scs = initialize_state(problem, algorithm, converging)
     state = AIT.DummyState(nothing, scs, 1)
 
-    @test !indicated_to_stop(converging, scs)
+    @test !is_active(converging, scs)
     @test !is_finished!(problem, algorithm, state)
-    @test !indicated_to_stop(converging, scs)
+    @test !is_active(converging, scs)
     state.iteration = 2
     @test is_finished!(problem, algorithm, state)
-    @test indicated_to_stop(converging, scs)
+    @test is_active(converging, scs)
     # a reset clears the record again
     initialize_state!(problem, algorithm, converging, scs)
-    @test !indicated_to_stop(converging, scs)
+    @test !is_active(converging, scs)
 
     # `at_iteration == 0` counts as having indicated to stop, a negative number does not
     scs.at_iteration = 0
-    @test indicated_to_stop(converging, scs)
+    @test is_active(converging, scs)
     scs.at_iteration = -1
-    @test !indicated_to_stop(converging, scs)
+    @test !is_active(converging, scs)
 
     # a state that records its status differently overrides the default
     unconventional = UnconventionalCriterion()
     algorithm = AIT.DummyAlgorithm(unconventional)
     ucs = initialize_state(problem, algorithm, unconventional)
-    @test !indicated_to_stop(unconventional, ucs)
+    @test !is_active(unconventional, ucs)
     @test !indicates_convergence(unconventional, ucs)
     ucs.stopped = true
-    @test indicated_to_stop(unconventional, ucs)
+    @test is_active(unconventional, ucs)
     @test indicates_convergence(unconventional, ucs)
 end
 
@@ -381,7 +381,7 @@ end
     state = AIT.DummyState(nothing, scs, 1)
 
     @test is_finished!(problem, algorithm, state)
-    @test indicated_to_stop(silent, scs)
+    @test is_active(silent, scs)
     # neither `get_reason` nor `indicates_convergence` is implemented, and both fall back
     # conservatively instead of throwing a `MethodError`
     @test isnothing(get_reason(silent, scs))
@@ -398,7 +398,7 @@ end
     state = AIT.DummyState(nothing, scs, 1)
 
     @test is_finished!(problem, algorithm, state)
-    @test indicated_to_stop(stop_when, scs)
+    @test is_active(stop_when, scs)
     @test isnothing(get_reason(stop_when, scs))
     @test !indicates_convergence(stop_when, scs)
 
@@ -453,7 +453,7 @@ end
 
     active = get_active_stopping_criteria(algorithm, state)
     @test map(first, active) == [converging, budget, timer]
-    @test all(((c, cs),) -> indicated_to_stop(c, cs), active)
+    @test all(((c, cs),) -> is_active(c, cs), active)
     # the groups themselves are recursed into, not reported
     @test !any(c -> c isa Union{StopWhenAll, StopWhenAny}, map(first, active))
 
@@ -474,7 +474,7 @@ end
     @test is_finished!(problem, algorithm, state)
 
     @test get_reason(algorithm, state) == get_reason(stop_when, scs)
-    @test indicated_to_stop(algorithm, state) == indicated_to_stop(stop_when, scs)
+    @test is_active(algorithm, state) == is_active(stop_when, scs)
     @test indicates_convergence(algorithm, state) == indicates_convergence(stop_when, scs)
     @test get_active_stopping_criteria(algorithm, state) ==
         get_active_stopping_criteria(stop_when, scs)

--- a/test/stopping_criterion.jl
+++ b/test/stopping_criterion.jl
@@ -79,6 +79,49 @@ end
 AlgorithmsInterface.get_reason(::CountingCriterion, ::CountingCriterionState) = nothing
 AlgorithmsInterface.indicates_convergence(::CountingCriterion) = false
 
+# Indicates to stop immediately, but implements nothing beyond the bare minimum: no `get_reason`
+# and no `indicates_convergence`, so it exercises the fallbacks for both.
+struct SilentCriterion <: StoppingCriterion end
+AlgorithmsInterface.initialize_state(::Problem, ::Algorithm, ::SilentCriterion; kwargs...) =
+    DefaultStoppingCriterionState()
+function AlgorithmsInterface.initialize_state!(
+        ::Problem, ::Algorithm, ::SilentCriterion,
+        stopping_criterion_state::DefaultStoppingCriterionState; kwargs...,
+    )
+    stopping_criterion_state.at_iteration = -1
+    return stopping_criterion_state
+end
+AlgorithmsInterface.is_finished(
+    ::Problem, ::Algorithm, ::State, ::SilentCriterion, ::DefaultStoppingCriterionState
+) = true
+function AlgorithmsInterface.is_finished!(
+        ::Problem, ::Algorithm, state::State, ::SilentCriterion,
+        stopping_criterion_state::DefaultStoppingCriterionState,
+    )
+    stopping_criterion_state.at_iteration = state.iteration
+    return true
+end
+
+# Records its status somewhere other than `at_iteration`, so it has to override
+# `indicated_to_stop` rather than rely on the default.
+struct UnconventionalCriterion <: StoppingCriterion end
+mutable struct UnconventionalCriterionState <: StoppingCriterionState
+    stopped::Bool
+end
+AlgorithmsInterface.initialize_state(::Problem, ::Algorithm, ::UnconventionalCriterion; kwargs...) =
+    UnconventionalCriterionState(false)
+function AlgorithmsInterface.initialize_state!(
+        ::Problem, ::Algorithm, ::UnconventionalCriterion,
+        stopping_criterion_state::UnconventionalCriterionState; kwargs...,
+    )
+    stopping_criterion_state.stopped = false
+    return stopping_criterion_state
+end
+AlgorithmsInterface.indicated_to_stop(
+    ::UnconventionalCriterion, stopping_criterion_state::UnconventionalCriterionState
+) = stopping_criterion_state.stopped
+AlgorithmsInterface.indicates_convergence(::UnconventionalCriterion) = true
+
 @testset "StopAfterIteration" begin
     s1 = StopAfterIteration(2)
     @test s1 isa StoppingCriterion
@@ -95,6 +138,16 @@ AlgorithmsInterface.indicates_convergence(::CountingCriterion) = false
     s1_state.at_iteration = 2
     @test startswith(get_reason(s1, s1_state), "At iteration 2")
     @test endswith(summary(s1, s1_state), ": reached")
+
+    # `get_reason` and `summary` are both gated on `indicated_to_stop`, so they agree even for
+    # an `at_iteration` below `max_iterations`
+    s2 = StopAfterIteration(10)
+    s2_state = initialize_state(problem, AIT.DummyAlgorithm(s2), s2)
+    @test isnothing(get_reason(s2, s2_state))
+    @test endswith(summary(s2, s2_state), ": not reached")
+    s2_state.at_iteration = 3
+    @test !isnothing(get_reason(s2, s2_state))
+    @test endswith(summary(s2, s2_state), ": reached")
 end
 
 @testset "StopAfter" begin
@@ -278,4 +331,52 @@ end
     # a reset clears the tally again
     initialize_state!(problem, algorithm, stop_when, scs)
     @test scs.criteria_states[1].calls == 0
+end
+
+@testset "indicated_to_stop" begin
+    converging = StopWhenConverged(2)
+    algorithm = AIT.DummyAlgorithm(converging)
+    scs = initialize_state(problem, algorithm, converging)
+    state = AIT.DummyState(nothing, scs, 1)
+
+    @test !indicated_to_stop(converging, scs)
+    @test !is_finished!(problem, algorithm, state)
+    @test !indicated_to_stop(converging, scs)
+    state.iteration = 2
+    @test is_finished!(problem, algorithm, state)
+    @test indicated_to_stop(converging, scs)
+    # a reset clears the record again
+    initialize_state!(problem, algorithm, converging, scs)
+    @test !indicated_to_stop(converging, scs)
+
+    # `at_iteration == 0` counts as having indicated to stop, a negative number does not
+    scs.at_iteration = 0
+    @test indicated_to_stop(converging, scs)
+    scs.at_iteration = -1
+    @test !indicated_to_stop(converging, scs)
+
+    # a state that records its status differently overrides the default
+    unconventional = UnconventionalCriterion()
+    algorithm = AIT.DummyAlgorithm(unconventional)
+    ucs = initialize_state(problem, algorithm, unconventional)
+    @test !indicated_to_stop(unconventional, ucs)
+    @test !indicates_convergence(unconventional, ucs)
+    ucs.stopped = true
+    @test indicated_to_stop(unconventional, ucs)
+    @test indicates_convergence(unconventional, ucs)
+end
+
+@testset "fallbacks for a minimal criterion" begin
+    silent = SilentCriterion()
+    algorithm = AIT.DummyAlgorithm(silent)
+    scs = initialize_state(problem, algorithm, silent)
+    state = AIT.DummyState(nothing, scs, 1)
+
+    @test is_finished!(problem, algorithm, state)
+    @test indicated_to_stop(silent, scs)
+    # neither `get_reason` nor `indicates_convergence` is implemented, and both fall back
+    # conservatively instead of throwing a `MethodError`
+    @test isnothing(get_reason(silent, scs))
+    @test !indicates_convergence(silent)
+    @test !indicates_convergence(silent, scs)
 end

--- a/test/stopping_criterion.jl
+++ b/test/stopping_criterion.jl
@@ -380,3 +380,25 @@ end
     @test !indicates_convergence(silent)
     @test !indicates_convergence(silent, scs)
 end
+
+@testset "group get_reason without any message" begin
+    # A group that indicated to stop, but whose only active child has no message, must report
+    # `nothing`: the empty string would read as a message to any consumer.
+    stop_when = StopWhenAny(SilentCriterion())
+    algorithm = AIT.DummyAlgorithm(stop_when)
+    scs = initialize_state(problem, algorithm, stop_when)
+    state = AIT.DummyState(nothing, scs, 1)
+
+    @test is_finished!(problem, algorithm, state)
+    @test indicated_to_stop(stop_when, scs)
+    @test isnothing(get_reason(stop_when, scs))
+    @test !indicates_convergence(stop_when, scs)
+
+    # mixing in a child with a message reports that message only
+    stop_when = SilentCriterion() | StopWhenConverged(1)
+    algorithm = AIT.DummyAlgorithm(stop_when)
+    scs = initialize_state(problem, algorithm, stop_when)
+    state = AIT.DummyState(nothing, scs, 1)
+    @test is_finished!(problem, algorithm, state)
+    @test get_reason(stop_when, scs) == "Converged at iteration 1.\n"
+end


### PR DESCRIPTION
This PR aims to port over some of the newer Manopt.jl things that didn't fully make it into the package, and improve some of the stopping criterion ergonomics.

The first thing is the ability to ask the question "has this algorithm converged", based on the state of the stopping criteria. The big thing here is that reaching iteration count does not mean convergence, but reaching tolerance criterion does, in other words this is a **static** property of the specific stopping criterion.
For this, I added `indicates_convergence(criterion)` as the static trait, and `indicates_convergence(criterion, state)` as the actual runtime check.

A second thing is that in some of the fixes (see list below), it become apparent that we were using `!isnothing(get_reason(...))` as a check for "has this criterion fired". Since there were some small mistakes in there, I factored that out into a more human-readable function that bundles this instead: `indicated_to_stop` is the machine-readable variant of `get_reason`.

Then, I actually tied together the stopping and logging system by a `StopReasonAction`, which basically just writes the reason for stopping if called.

---

A list of small fixes as well:

- `any` and `all` are short-circuiting, so for stateful criteria this could make `is_finished!` end up not being called once per iteration on the states
- `indicates_convergence` had `isnothing(get_reason(...))`, which indicates non-convergence
- `"nothing"` ended up being printed in various `get_reason` calls for stopping groups.
- ...

---

Kept for future PRs:

- An interface for logging stopping criterion state, e.g. printing per step how far we are from stopping. (for example "iter 4/100", "time 45s / 10min", "tol 1.2e-3 / 1e-8")
- A hook for a tolerance-based stopping criterion
- stopping criterion factory
- any breaking changes 🙃 